### PR TITLE
profiles: drop updates/1Q-2019

### DIFF
--- a/profiles/updates/1Q-2019
+++ b/profiles/updates/1Q-2019
@@ -1,1 +1,0 @@
-move sci-libs/libmed sci-libs/med-fichier


### PR DESCRIPTION
neither libmed nor med-fichier are in the overlay anymore and the move
brings trouble on depcleans with freecad depending on med-fichier which
isn't existing at all.

Signed-off-by: Bernd Waibel <waebbl@gmail.com>