### PR TITLE
sci-libs/opencascade: re-add -f flag to rm

### DIFF
--- a/sci-libs/opencascade/opencascade-7.3.0.ebuild
+++ b/sci-libs/opencascade/opencascade-7.3.0.ebuild
@@ -135,9 +135,9 @@ src_install() {
 	doins "${T}/${PV}"
 
 	# remove examples
-	use examples || (rm -r "${ED}/usr/$(get_libdir)/${P}/ros/share/${PN}/samples" || die)
-	use java || (rm -r "${ED}/usr/$(get_libdir)/${P}/ros/share/${PN}/samples/java" || die)
-	use qt5 || (rm -r "${ED}/usr/$(get_libdir)/${P}/ros/share/${PN}/samples/qt" || die)
+	use examples || (rm -rf "${ED}/usr/$(get_libdir)/${P}/ros/share/${PN}/samples" || die)
+	use java || (rm -rf "${ED}/usr/$(get_libdir)/${P}/ros/share/${PN}/samples/java" || die)
+	use qt5 || (rm -rf "${ED}/usr/$(get_libdir)/${P}/ros/share/${PN}/samples/qt" || die)
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Ensure no error is thrown, if the directory doesn't exist.

Package-Manager: Portage-2.3.67, Repoman-2.3.15
Signed-off-by: Bernd Waibel <waebbl@gmail.com>