### PR TITLE
media-gfx/freecad-9999: fixes for issue #120

### DIFF
--- a/media-gfx/freecad/freecad-0.18.2-r1.ebuild
+++ b/media-gfx/freecad/freecad-0.18.2-r1.ebuild
@@ -64,7 +64,7 @@ RDEPEND="
 	${PYTHON_DEPS}
 	>=dev-cpp/eigen-3.3.1:3
 	dev-libs/OpenNI2[opengl(+)]
-	dev-libs/boost:=[python,threads,${PYTHON_USEDEP}]
+	dev-libs/boost:=[mpi?,python,threads,${PYTHON_USEDEP}]
 	dev-libs/libspnav
 	dev-libs/xerces-c
 	dev-python/matplotlib[${PYTHON_USEDEP}]
@@ -143,7 +143,7 @@ PATCHES=(
 
 CHECKREQS_DISK_BUILD="6G"
 
-S="${WORKDIR}/FreeCAD-${PV}"
+[[ ${PV} == *9999 ]] && S="${WORKDIR}/freecad-${PV}" || S="${WORKDIR}/FreeCAD-${PV}"
 
 pkg_setup() {
 	check-reqs_pkg_setup
@@ -271,10 +271,11 @@ src_install() {
 	rm "${ED}"/usr/share/${PN}/data/${PN}.xpm || die
 
 	if use doc; then
-		cp -r "${WORKDIR}/FreeCAD 0_18 Quick Reference Guide" "${ED}/usr/share/doc/${PF}" || die
+		[[ ${PV} == *9999 ]] && einfo "Docs are not downloaded for ${PV}" \
+			|| (cp -r "${WORKDIR}/FreeCAD 0_18 Quick Reference Guide" "${ED}/usr/share/doc/${PF}" || die)
 	fi
 
-	python_optimize "${ED%/}"/usr/share/${PN}/data/Mod/ "${ED%/}"/usr/$(get_libdir)/${PN}{/Ext,/Mod}/
+	python_optimize "${ED}"/usr/share/${PN}/data/Mod/ "${ED}"/usr/$(get_libdir)/${PN}{/Ext,/Mod}/
 }
 
 #pkg_postinst() {

--- a/media-gfx/freecad/metadata.xml
+++ b/media-gfx/freecad/metadata.xml
@@ -95,10 +95,11 @@
 		<flag name="surface">
 			Build the surface module and workbench
 		</flag>
+		<!-- FIXME: comment this until we can build it external?
 		<flag name="system-smesh">
-			<!-- FIXME: remove this until we can build it external? -->
 			Use system-provided smesh (not implemented)
 		</flag>
+		-->
 		<flag name="techdraw">
 			Build the techdraw module and workbench, a more advanced and 
 			feature-rich successor of the drawing workbench


### PR DESCRIPTION
Sync with changes from 0.18.2
Add mpi USE flag and propagate it to dependencies
Change ${S} to point to correct path for both, versioned and live ebuild
Only install docs, for versioned ebuilds