### PR TITLE
profiles/package.use.mask

### DIFF
--- a/profiles/package.use.mask
+++ b/profiles/package.use.mask
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # This file requires >=portage-2.1.1
@@ -7,11 +7,10 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Bernd Waibel <waebbl@gmail.com> (30 Aug 2019)
+# Has runtime issues, so FEM is not working properly
+media-gfx/freecad netgen
+
 # Bernd Waibel <waebbl@gmail.com> (10 Feb 2019)
 # GUI needs internal togl, build is currently broken
 sci-mathematics/netgen gui
-
-# Bernd Waibel <waebbl@gmail.com> (01 Oct 2018)
-# External smesh support needs testing.
-# Also no package currently in the tree.
-media-gfx/freecad system-smesh


### PR DESCRIPTION
* remove media-gfx/freecad system-smesh, the USE flag has been removed
	until we have a package available for it.
* add media-gfx/freecad netgen: it has runtime issues with libinterface.so
	from sci-mathematics/netgen which crashes freecad.

Signed-off-by: Bernd Waibel <waebbl@gmail.com>