### PR TITLE
sci-libs/vtk: add missing deps

### DIFF
--- a/sci-libs/vtk/vtk-8.2.0.ebuild
+++ b/sci-libs/vtk/vtk-8.2.0.ebuild
@@ -40,6 +40,8 @@ REQUIRED_USE="
 
 RDEPEND="
 	app-arch/lz4
+	dev-db/sqlite
+	dev-libs/double-conversion:=
 	dev-libs/expat
 	dev-libs/jsoncpp:=
 	dev-libs/libxml2:2


### PR DESCRIPTION
On a test, I noticed that dev-libs/double-conversion and dev-db/sqlite
are needed for default configuration (+X). The missing dependencies
are added in this patch.

Package-Manager: Portage-2.3.75, Repoman-2.3.17
Signed-off-by: Bernd Waibel <waebbl@gmail.com>