### PR TITLE
media-gfx/freecad: fix mpi USE flag

### DIFF
--- a/media-gfx/freecad/freecad-0.18.3.ebuild
+++ b/media-gfx/freecad/freecad-0.18.3.ebuild
@@ -89,8 +89,8 @@ RDEPEND="
 	media-libs/qhull
 	sci-libs/flann[mpi?,openmp]
 	|| (
-		>=sci-libs/med-4.0.0-r1[fortran,mpi?,python,${PYTHON_USEDEP}]
-		>=sci-libs/libmed-4.0.0[fortran,mpi?,python,${PYTHON_USEDEP}]
+		>=sci-libs/med-4.0.0-r1[mpi(+)?,python,${PYTHON_USEDEP}]
+		>=sci-libs/libmed-4.0.0[mpi?,python,${PYTHON_USEDEP}]
 	)
 	sci-libs/orocos_kdl:=
 	sci-libs/opencascade:7.3.0[vtk(+)]

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -89,8 +89,8 @@ RDEPEND="
 	media-libs/qhull
 	sci-libs/flann[mpi?,openmp]
 	|| (
-		>=sci-libs/med-4.0.0-r1[fortran,mpi?,python,${PYTHON_USEDEP}]
-		>=sci-libs/libmed-4.0.0[fortran,mpi?,python,${PYTHON_USEDEP}]
+		>=sci-libs/med-4.0.0-r1[mpi(+)?,python,${PYTHON_USEDEP}]
+		>=sci-libs/libmed-4.0.0[mpi?,python,${PYTHON_USEDEP}]
 	)
 	sci-libs/orocos_kdl:=
 	sci-libs/opencascade:7.3.0[vtk(+)]


### PR DESCRIPTION
The patch fixes the mpi USE flag for sci-libs/med, which has been dropped
by the merge of libmed with med. As the USE flag will possibly come back
in the future, the patch uses mpi(+)? syntax.
Also removing fortran USE dependency from med. This actually isn't used by
freecad, it only links to the C library.

Closes: https://github.com/waebbl/waebbl-gentoo/issues/141
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Bernd Waibel <waebbl@gmail.com>