### PR TITLE
Fix freecad installation

### DIFF
--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -277,9 +277,9 @@ src_install() {
 	doicon -s scalable "${S}"/src/Gui/Icons/${PN}.svg
 	newicon -s 64 -c mimetypes "${S}"/src/Gui/Icons/${PN}-doc.png application-x-extension-fcstd.png
 
-	rm "${ED}"/usr/share/${PN}/data/${PN}-{doc,icon-{16,32,48,64}}.png || die
-	rm "${ED}"/usr/share/${PN}/data/${PN}.svg || die
-	rm "${ED}"/usr/share/${PN}/data/${PN}.xpm || die
+	rm "${ED}"/usr/share/${PN}/data/${PN}-{doc,icon-{16,32,48,64}}.png
+	rm "${ED}"/usr/share/${PN}/data/${PN}.svg
+	rm "${ED}"/usr/share/${PN}/data/${PN}.xpm
 
 	if use doc; then
 		[[ ${PV} == *9999 ]] && einfo "Docs are not downloaded for ${PV}" \


### PR DESCRIPTION
......
-- Installing: /var/tmp/portage/media-gfx/freecad-9999/image/usr/share/freecad/data/examples/RobotExample.FCStd
-- Installing: /var/tmp/portage/media-gfx/freecad-9999/image/usr/share/freecad/data/examples/ArchDetail.FCStd
-- Installing: /var/tmp/portage/media-gfx/freecad-9999/image/usr/share/freecad/data/examples/FemCalculixCantilever2D.FCStd
-- Installing: /var/tmp/portage/media-gfx/freecad-9999/image/usr/share/freecad/data/examples/FemCalculixCantilever3D.FCStd
-- Installing: /var/tmp/portage/media-gfx/freecad-9999/image/usr/share/freecad/data/examples/FemCalculixCantilever3D_newSolver.FCStd
rm: cannot remove '/var/tmp/portage/media-gfx/freecad-9999/image/usr/share/freecad/data/freecad-doc.png': No such file or directory
rm: cannot remove '/var/tmp/portage/media-gfx/freecad-9999/image/usr/share/freecad/data/freecad-icon-16.png': No such file or directory
rm: cannot remove '/var/tmp/portage/media-gfx/freecad-9999/image/usr/share/freecad/data/freecad-icon-32.png': No such file or directory
rm: cannot remove '/var/tmp/portage/media-gfx/freecad-9999/image/usr/share/freecad/data/freecad-icon-48.png': No such file or directory
rm: cannot remove '/var/tmp/portage/media-gfx/freecad-9999/image/usr/share/freecad/data/freecad-icon-64.png': No such file or directory
 ESC[31;01m*ESC[0m ERROR: media-gfx/freecad-9999::waebbl failed (install phase):
 ESC[31;01m*ESC[0m   (no error message)
 ESC[31;01m*ESC[0m 
 ESC[31;01m*ESC[0m Call stack:
 ESC[31;01m*ESC[0m     ebuild.sh, line 125:  Called src_install
 ESC[31;01m*ESC[0m   environment, line 4378:  Called die
 ESC[31;01m*ESC[0m The specific snippet of code:
 ESC[31;01m*ESC[0m       rm "${ED}"/usr/share/${PN}/data/${PN}-{doc,icon-{16,32,48,64}}.png || die;
 ESC[31;01m*ESC[0m 
 ESC[31;01m*ESC[0m If you need support, post the output of `emerge --info '=media-gfx/freecad-9999::waebbl'`,
 ESC[31;01m*ESC[0m the complete build log and the output of `emerge -pqv '=media-gfx/freecad-9999::waebbl'`.
 ESC[31;01m*ESC[0m The complete build log is located at '/var/tmp/portage/media-gfx/freecad-9999/temp/build.log'.
 ESC[31;01m*ESC[0m The ebuild environment file is located at '/var/tmp/portage/media-gfx/freecad-9999/temp/environment'.
 ESC[31;01m*ESC[0m Working directory: '/var/tmp/portage/media-gfx/freecad-9999/work/freecad-9999'
 ESC[31;01m*ESC[0m S: '/var/tmp/portage/media-gfx/freecad-9999/work/freecad-9999'