### PR TITLE
dev-python/shiboken: fix an #include directive issue

### DIFF
--- a/dev-python/shiboken/files/shiboken-5.11.1-include-QStringList.patch
+++ b/dev-python/shiboken/files/shiboken-5.11.1-include-QStringList.patch
@@ -1,0 +1,25 @@
+From ff341ed106a05cf730ecdb9950b8e14ee84ad7f7 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl@gmail.com>
+Date: Wed, 1 Jan 2020 11:34:20 +0100
+Subject: [PATCH] Add a missing #include directive to find QStringList
+
+Signed-off-by: Bernd Waibel <waebbl@gmail.com>
+---
+ ApiExtractor/clangparser/clangutils.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/ApiExtractor/clangparser/clangutils.h b/ApiExtractor/clangparser/clangutils.h
+index 98d0c97..01b5a41 100644
+--- a/ApiExtractor/clangparser/clangutils.h
++++ b/ApiExtractor/clangparser/clangutils.h
+@@ -32,6 +32,7 @@
+ #include <clang-c/Index.h>
+ #include <QtCore/QPair>
+ #include <QtCore/QString>
++#include <QtCore/QStringList>
+ #include <QtCore/QVector>
+ 
+ QT_FORWARD_DECLARE_CLASS(QDebug)
+-- 
+2.24.1
+

--- a/dev-python/shiboken/shiboken-5.11.1.ebuild
+++ b/dev-python/shiboken/shiboken-5.11.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
+PYTHON_COMPAT=( python3_{6,7} )
 
-inherit cmake-utils llvm python-r1
+inherit cmake llvm python-r1
 
 DESCRIPTION="Tool for creating Python bindings for C++ libraries"
 HOMEPAGE="https://wiki.qt.io/PySide2"
@@ -53,6 +53,7 @@ DOCS=( AUTHORS )
 PATCHES=(
 	"${FILESDIR}"/${P}-fix-clang-include-path.patch
 	"${FILESDIR}"/${P}-fix-warnings.patch
+	"${FILESDIR}"/${P}-include-QStringList.patch
 )
 
 # Ensure the path returned by get_llvm_prefix() contains clang as well.
@@ -73,7 +74,7 @@ src_prepare() {
 
 #	eapply "${FILESDIR}"/${P}-fix-warnings.patch
 
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }
 
 src_configure() {
@@ -83,22 +84,22 @@ src_configure() {
 			-DPYTHON_EXECUTABLE="${PYTHON}"
 			-DPYTHON_SITE_PACKAGES="$(python_get_sitedir)"
 		)
-		cmake-utils_src_configure
+		cmake_src_configure
 	}
 	python_foreach_impl configuration
 }
 
 src_compile() {
-	python_foreach_impl cmake-utils_src_compile
+	python_foreach_impl cmake_src_compile
 }
 
 src_test() {
-	python_foreach_impl cmake-utils_src_test
+	python_foreach_impl cmake_src_test
 }
 
 src_install() {
 	installation() {
-		cmake-utils_src_install
+		cmake_src_install
 		mv "${ED%/}"/usr/$(get_libdir)/pkgconfig/${PN}2{,-${EPYTHON}}.pc || die
 	}
 	python_foreach_impl installation


### PR DESCRIPTION
- Fix an issue where QStringList was not found.
- Update copyright year
- Modify to use new cmake.eclass

Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Bernd Waibel <waebbl@gmail.com>