### PR TITLE
sci-libs/vtk: fix dependency issues

### DIFF
--- a/profiles/package.use.mask
+++ b/profiles/package.use.mask
@@ -7,6 +7,11 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Bernd Waibel <waebbl@gmail.com> (05 Feb 2020)
+# Some dependencies of vtk don't support python 3.{7,8} yet
+sci-libs/vtk python_single_target_python3_7 python_targets_python3_7
+sci-libs/vtk python_single_target_python3_8 python_targets_python3_8
+
 # Bernd Waibel <waebbl@gmail.com> (20 Jan 2020)
 # Doesn't compile against dev-lang/spidermonkey:60
 media-libs/coin javascript

--- a/sci-libs/vtk/metadata.xml
+++ b/sci-libs/vtk/metadata.xml
@@ -12,7 +12,6 @@
     <flag name="gdal">Support for gdal formated data</flag>
     <flag name="imaging">Building Imaging modules</flag>
     <flag name="json">Support for json formated data</flag>
-    <flag name="kaapi">Use <pkg>sci-libs/xkaapi</pkg> to handle smp support</flag>
     <flag name="offscreen">Offscreen rendering through OSMesa</flag>
     <flag name="rendering">Building Redering modules</flag>
     <flag name="tbb">Use <pkg>dev-cpp/tbb</pkg> to handle smp support</flag>

--- a/sci-libs/vtk/vtk-8.2.0.ebuild
+++ b/sci-libs/vtk/vtk-8.2.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_6 )
 WEBAPP_OPTIONAL=yes
 WEBAPP_MANUAL_SLOT=yes
 
@@ -26,7 +26,7 @@ LICENSE="BSD LGPL-2"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 SLOT="0"
 IUSE="
-	all-modules aqua boost doc examples imaging ffmpeg gdal java json kaapi mpi
+	all-modules aqua boost doc examples imaging ffmpeg gdal java json mpi
 	mysql odbc offscreen postgres python qt5 rendering tbb theora
 	video_cards_nvidia views web R +X xdmf2"
 
@@ -56,7 +56,6 @@ RDEPEND="
 	sci-libs/exodusii
 	sci-libs/hdf5:=
 	sci-libs/netcdf-cxx:3
-	<sci-libs/proj-6
 	sys-libs/zlib
 	virtual/jpeg:0
 	virtual/opengl
@@ -71,7 +70,6 @@ RDEPEND="
 	ffmpeg? ( virtual/ffmpeg )
 	gdal? ( sci-libs/gdal )
 	java? ( >=virtual/jdk-1.7:* )
-	kaapi? ( <sci-libs/xkaapi-3 )
 	mpi? (
 		virtual/mpi[cxx,romio]
 		python? ( dev-python/mpi4py[${PYTHON_USEDEP}] )
@@ -165,6 +163,8 @@ src_configure() {
 		-DVTK_USE_SYSTEM_GLEW=ON
 		-DVTK_USE_SYSTEM_HDF5=ON
 		-DVTK_USE_SYSTEM_JPEG=ON
+		# only support proj-4 which conflicts with several other packages requiring >=proj-{5,6}
+		-DVTK_USE_SYSTEM_LIBPROJ=OFF
 		-DVTK_USE_SYSTEM_LIBXML2=ON
 		-DVTK_USE_SYSTEM_MPI4PY=ON
 		-DVTK_USE_SYSTEM_NETCDF=ON
@@ -213,9 +213,7 @@ src_configure() {
 		mycmakeargs+=( -DJAVAC_OPTIONS=${javacargs// /;} )
 	fi
 
-	if use kaapi; then
-		mycmakeargs+=( -DVTK_SMP_IMPLEMENTATION_TYPE="Kaapi" )
-	elif use tbb; then
+	if use tbb; then
 		mycmakeargs+=( -DVTK_SMP_IMPLEMENTATION_TYPE="TBB" )
 	else
 		mycmakeargs+=( -DVTK_SMP_IMPLEMENTATION_TYPE="Sequential" )


### PR DESCRIPTION
- remove dependencies on sci-libs/proj and sci-libs/xkaapi, the latter to stay in sync with Gentoo version
- remove support for python 3.{7,8} again. They lead to many fatal errors with repoman, due to some dependencies on a few arches don't support them.

- also add masks for python 3.{7,8} to profiles/package.use.mask