### PR TITLE
media-gfx/freecad: switch pybind11 category

### DIFF
--- a/media-gfx/freecad/files/freecad-0.18.4-0004-fix-std-namespace-issues.patch
+++ b/media-gfx/freecad/files/freecad-0.18.4-0004-fix-std-namespace-issues.patch
@@ -1,0 +1,732 @@
+From 657e1f72f33bf49e8f61495f268dac88a9e22e64 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl@gmail.com>
+Date: Thu, 6 Feb 2020 20:42:35 +0100
+Subject: [PATCH] Fix std:: namespace issues
+
+See https://forum.freecadweb.org/viewtopic.php?f=4&t=43140 and
+https://github.com/FreeCAD/FreeCAD/commit/851e3d9847c5043a604a544b502c51e8c628e96c
+for this recurring issue.
+
+Also patches other occurences of missing std:: namespaces not covered
+by the above links.
+
+Signed-off-by: Bernd Waibel <waebbl@gmail.com>
+---
+ src/3rdParty/salomesmesh/inc/Rn.h          |   4 +-
+ src/Mod/Drawing/App/DrawingExport.cpp      | 218 ++++++++++-----------
+ src/Mod/Part/App/Geometry.cpp              |  38 ++--
+ src/Mod/Part/App/Geometry2d.cpp            |  22 +--
+ src/Mod/Part/App/PropertyTopoShape.cpp     |   6 +-
+ src/Mod/Raytracing/App/AppRaytracingPy.cpp |  22 +--
+ src/Mod/Raytracing/App/LuxFeature.cpp      |  30 +--
+ src/Mod/Raytracing/App/RayFeature.cpp      |  16 +-
+ 8 files changed, 178 insertions(+), 178 deletions(-)
+
+diff --git a/src/3rdParty/salomesmesh/inc/Rn.h b/src/3rdParty/salomesmesh/inc/Rn.h
+index 6ec871d..e92d227 100644
+--- a/src/3rdParty/salomesmesh/inc/Rn.h
++++ b/src/3rdParty/salomesmesh/inc/Rn.h
+@@ -180,12 +180,12 @@ class R4: public R3
+ {
+   friend std::ostream& operator <<(std::ostream& f, const R4 & P )
+   { f << P.x << ' ' << P.y << ' ' << P.z << ' ' << P.omega; return f; }
+-  friend istream& operator >>(istream& f,  R4 & P)
++  friend std::istream& operator >>(std::istream& f,  R4 & P)
+   { f >> P.x >>  P.y >>  P.z >> P.omega ; return f; }
+ 
+   friend std::ostream& operator <<(std::ostream& f, const R4 * P )
+   { f << P->x << ' ' << P->y << ' ' << P->z << ' ' << P->omega; return f; }
+-  friend istream& operator >>(istream& f,  R4 * P)
++  friend std::istream& operator >>(std::istream& f,  R4 * P)
+   { f >> P->x >>  P->y >>  P->z >> P->omega ; return f; }
+ 
+ public:  
+diff --git a/src/Mod/Drawing/App/DrawingExport.cpp b/src/Mod/Drawing/App/DrawingExport.cpp
+index 0c3c232..822011f 100644
+--- a/src/Mod/Drawing/App/DrawingExport.cpp
++++ b/src/Mod/Drawing/App/DrawingExport.cpp
+@@ -434,7 +434,7 @@ void SVGOutput::printGeneric(const BRepAdaptor_Curve& c, int id, std::ostream& o
+             out << c << " " << nodes(i).X() << " " << nodes(i).Y()<< " " ; 
+             c = 'L';
+         }
+-        out << "\" />" << endl;
++        out << "\" />" << std::endl;
+     } else if (c.GetType() == GeomAbs_Line) {
+         //BRep_Tool::Polygon3D assumes the edge has polygon representation - ie already been "tessellated"
+         //this is not true for all edges, especially "floating edges"
+@@ -447,7 +447,7 @@ void SVGOutput::printGeneric(const BRepAdaptor_Curve& c, int id, std::ostream& o
+         out << c << " " << s.X() << " " << s.Y()<< " " ; 
+         c = 'L';
+         out << c << " " << e.X() << " " << e.Y()<< " " ; 
+-        out << "\" />" << endl;
++        out << "\" />" << std::endl;
+     }
+ }
+ 
+@@ -485,10 +485,10 @@ std::string DXFOutput::exportEdges(const TopoDS_Shape& input)
+ 
+ void DXFOutput::printHeader( std::ostream& out)
+ {
+-        out	 << 0          << endl;
+-        out << "SECTION"  << endl;
+-        out << 2          << endl;
+-        out << "ENTITIES" << endl;
++        out	 << 0          << std::endl;
++        out << "SECTION"  << std::endl;
++        out << 2          << std::endl;
++        out << "ENTITIES" << std::endl;
+ }
+ 
+ void DXFOutput::printCircle(const BRepAdaptor_Curve& c, std::ostream& out)
+@@ -512,22 +512,22 @@ void DXFOutput::printCircle(const BRepAdaptor_Curve& c, std::ostream& out)
+     if (s.SquareDistance(e) < 0.001) {
+         //out << "<circle cx =\"" << p.X() << "\" cy =\"" 
+             //<< p.Y() << "\" r =\"" << r << "\" />";
+-	    out << 0			<< endl;
+-	    out << "CIRCLE"		<< endl;
+-	    out << 8			<< endl;	// Group code for layer name
+-	    out << "sheet_layer"	<< endl;	// Layer number
+-        out << "100"        << endl;
+-        out << "AcDbEntity" << endl;
+-        out << "100"        << endl;
+-        out << "AcDbCircle"   << endl;
+-	    out << 10			<< endl;	// Centre X
+-	    out << p.X()		<< endl;	// X in WCS coordinates
+-	    out << 20			<< endl;
+-	    out << p.Y()		<< endl;	// Y in WCS coordinates
+-	    out << 30			<< endl;
+-	    out << 0		<< endl;	// Z in WCS coordinates-leaving flat
+-	    out << 40			<< endl;	//
+-	    out << r		<< endl;	// Radius
++	    out << 0			<< std::endl;
++	    out << "CIRCLE"		<< std::endl;
++	    out << 8			<< std::endl;	// Group code for layer name
++	    out << "sheet_layer"	<< std::endl;	// Layer number
++        out << "100"        << std::endl;
++        out << "AcDbEntity" << std::endl;
++        out << "100"        << std::endl;
++        out << "AcDbCircle"   << std::endl;
++	    out << 10			<< std::endl;	// Centre X
++	    out << p.X()		<< std::endl;	// X in WCS coordinates
++	    out << 20			<< std::endl;
++	    out << p.Y()		<< std::endl;	// Y in WCS coordinates
++	    out << 30			<< std::endl;
++	    out << 0		<< std::endl;	// Z in WCS coordinates-leaving flat
++	    out << 40			<< std::endl;	//
++	    out << r		<< std::endl;	// Radius
+                                 }
+ 
+ 
+@@ -555,28 +555,28 @@ void DXFOutput::printCircle(const BRepAdaptor_Curve& c, std::ostream& out)
+ 		double temp = start_angle;
+ 		start_angle = end_angle;
+ 		end_angle = temp;}
+-	out << 0			<< endl;
+-	out << "ARC"		<< endl;
+-	out << 8			<< endl;	// Group code for layer name
+-	out << "sheet_layer"	<< endl;	// Layer number
+-    out << "100"        << endl;
+-    out << "AcDbEntity" << endl;
+-    out << "100"        << endl;
+-    out << "AcDbCircle" << endl;
+-	out << 10			<< endl;	// Centre X
+-	out << p.X()		<< endl;	// X in WCS coordinates
+-	out << 20			<< endl;
+-	out << p.Y()		<< endl;	// Y in WCS coordinates
+-	out << 30			<< endl;
+-	out << 0		<< endl;	// Z in WCS coordinates
+-	out << 40			<< endl;	//
+-	out << r		<< endl;	// Radius
+-    out << "100"        << endl;
+-    out << "AcDbArc" << endl;
+-	out << 50			<< endl;
+-	out << start_angle	<< endl;	// Start angle
+-	out << 51			<< endl;
+-	out << end_angle	<< endl;	// End angle
++	out << 0			<< std::endl;
++	out << "ARC"		<< std::endl;
++	out << 8			<< std::endl;	// Group code for layer name
++	out << "sheet_layer"	<< std::endl;	// Layer number
++    out << "100"        << std::endl;
++    out << "AcDbEntity" << std::endl;
++    out << "100"        << std::endl;
++    out << "AcDbCircle" << std::endl;
++	out << 10			<< std::endl;	// Centre X
++	out << p.X()		<< std::endl;	// X in WCS coordinates
++	out << 20			<< std::endl;
++	out << p.Y()		<< std::endl;	// Y in WCS coordinates
++	out << 30			<< std::endl;
++	out << 0		<< std::endl;	// Z in WCS coordinates
++	out << 40			<< std::endl;	//
++	out << r		<< std::endl;	// Radius
++    out << "100"        << std::endl;
++    out << "AcDbArc" << std::endl;
++	out << 50			<< std::endl;
++	out << start_angle	<< std::endl;	// Start angle
++	out << 51			<< std::endl;
++	out << end_angle	<< std::endl;	// End angle
+ 
+ 
+ 
+@@ -628,32 +628,32 @@ void DXFOutput::printEllipse(const BRepAdaptor_Curve& c, int /*id*/, std::ostrea
+ 		start_angle = end_angle;
+ 		end_angle = temp;
+ 	}
+-	out << 0			<< endl;
+-	out << "ELLIPSE"		<< endl;
+-	out << 8			<< endl;	// Group code for layer name
+-	out << "sheet_layer"	<< endl;	// Layer number
+-    out << "100"        << endl;
+-    out << "AcDbEntity" << endl;
+-    out << "100"        << endl;
+-    out << "AcDbEllipse"   << endl;
+-	out << 10			<< endl;	// Centre X
+-	out << p.X()		<< endl;	// X in WCS coordinates
+-	out << 20			<< endl;
+-	out << p.Y()		<< endl;	// Y in WCS coordinates
+-	out << 30			<< endl;
+-	out << 0		<< endl;	// Z in WCS coordinates
+-	out << 11			<< endl;	//
+-	out << major_x		<< endl;	// Major X
+-	out << 21			<< endl;
+-	out << major_y		<< endl;	// Major Y
+-	out << 31			<< endl;
+-	out << 0		<< endl;	// Major Z
+-	out << 40			<< endl;	//
+-	out << ratio		<< endl;	// Ratio
+-	out << 41		<< endl;
+-	out << start_angle	<< endl;	// Start angle
+-	out << 42		<< endl;
+-	out << end_angle	<< endl;	// End angle
++	out << 0			<< std::endl;
++	out << "ELLIPSE"		<< std::endl;
++	out << 8			<< std::endl;	// Group code for layer name
++	out << "sheet_layer"	<< std::endl;	// Layer number
++    out << "100"        << std::endl;
++    out << "AcDbEntity" << std::endl;
++    out << "100"        << std::endl;
++    out << "AcDbEllipse"   << std::endl;
++	out << 10			<< std::endl;	// Centre X
++	out << p.X()		<< std::endl;	// X in WCS coordinates
++	out << 20			<< std::endl;
++	out << p.Y()		<< std::endl;	// Y in WCS coordinates
++	out << 30			<< std::endl;
++	out << 0		<< std::endl;	// Z in WCS coordinates
++	out << 11			<< std::endl;	//
++	out << major_x		<< std::endl;	// Major X
++	out << 21			<< std::endl;
++	out << major_y		<< std::endl;	// Major Y
++	out << 31			<< std::endl;
++	out << 0		<< std::endl;	// Major Z
++	out << 40			<< std::endl;	//
++	out << ratio		<< std::endl;	// Ratio
++	out << 41		<< std::endl;
++	out << start_angle	<< std::endl;	// Start angle
++	out << 42		<< std::endl;
++	out << end_angle	<< std::endl;	// End angle
+ }
+ 
+ void DXFOutput::printBSpline(const BRepAdaptor_Curve& c, int id, std::ostream& out) //Not even close yet- DF 
+@@ -692,31 +692,31 @@ void DXFOutput::printBSpline(const BRepAdaptor_Curve& c, int id, std::ostream& o
+         spline->Poles(poles);
+ 
+ 
+-        str << 0 << endl
+-            << "SPLINE" << endl
+-            << 8 << endl // Group code for layer name
+-            << "sheet_layer" << endl // Layer name
+-            << "100"        << endl
+-            << "AcDbEntity" << endl
+-            << "100"        << endl
+-            << "AcDbSpline"   << endl
+-            << 70 << endl
+-            << spline->IsRational()*4 << endl //flags
+-            << 71 << endl << spline->Degree() << endl
+-            << 72 << endl << knotsequence.Length() << endl
+-            << 73 << endl << poles.Length() << endl
+-            << 74 << endl << 0 << endl; //fitpoints
++        str << 0 << std::endl
++            << "SPLINE" << std::endl
++            << 8 << std::endl // Group code for layer name
++            << "sheet_layer" << std::endl // Layer name
++            << "100"        << std::endl
++            << "AcDbEntity" << std::endl
++            << "100"        << std::endl
++            << "AcDbSpline"   << std::endl
++            << 70 << std::endl
++            << spline->IsRational()*4 << std::endl //flags
++            << 71 << std::endl << spline->Degree() << std::endl
++            << 72 << std::endl << knotsequence.Length() << std::endl
++            << 73 << std::endl << poles.Length() << std::endl
++            << 74 << std::endl << 0 << std::endl; //fitpoints
+ 
+         for (int i = knotsequence.Lower() ; i <= knotsequence.Upper(); i++) {
+-            str << 40 << endl << knotsequence(i) << endl;
++            str << 40 << std::endl << knotsequence(i) << std::endl;
+         }
+         for (int i = poles.Lower(); i <= poles.Upper(); i++) {
+             gp_Pnt pole = poles(i);
+-            str << 10 << endl << pole.X() << endl
+-                << 20 << endl << pole.Y() << endl
+-                << 30 << endl << pole.Z() << endl;
++            str << 10 << std::endl << pole.X() << std::endl
++                << 20 << std::endl << pole.Y() << std::endl
++                << 30 << std::endl << pole.Z() << std::endl;
+             if (spline->IsRational()) {
+-                str << 41 << endl << spline->Weight(i) << endl;
++                str << 41 << std::endl << spline->Weight(i) << std::endl;
+             }
+         }
+ 
+@@ -740,24 +740,24 @@ void DXFOutput::printGeneric(const BRepAdaptor_Curve& c, int /*id*/, std::ostrea
+     gp_Vec VE;
+     c.D1(uEnd, PE, VE);
+ 
+-    out << "0"			<< endl;
+-    out << "LINE"		<< endl;
+-    out << "8"			<< endl;	// Group code for layer name
+-    out << "sheet_layer" << endl; // Layer name 
+-    out << "100"        << endl;
+-    out << "AcDbEntity" << endl;
+-    out << "100"        << endl;
+-    out << "AcDbLine"   << endl;
+-    out << "10"			<< endl;	// Start point of line
+-    out << PS.X()		<< endl;	// X in WCS coordinates
+-    out << "20"			<< endl;
+-    out << PS.Y()		<< endl;	// Y in WCS coordinates
+-    out << "30"			<< endl;
+-    out << "0"		<< endl;	// Z in WCS coordinates
+-    out << "11"			<< endl;	// End point of line
+-    out << PE.X()		<< endl;	// X in WCS coordinates
+-    out << "21"			<< endl;
+-    out << PE.Y()		<< endl;	// Y in WCS coordinates
+-    out << "31"			<< endl;
+-    out << "0"		<< endl;	// Z in WCS coordinates
++    out << "0"			<< std::endl;
++    out << "LINE"		<< std::endl;
++    out << "8"			<< std::endl;	// Group code for layer name
++    out << "sheet_layer" << std::endl; // Layer name 
++    out << "100"        << std::endl;
++    out << "AcDbEntity" << std::endl;
++    out << "100"        << std::endl;
++    out << "AcDbLine"   << std::endl;
++    out << "10"			<< std::endl;	// Start point of line
++    out << PS.X()		<< std::endl;	// X in WCS coordinates
++    out << "20"			<< std::endl;
++    out << PS.Y()		<< std::endl;	// Y in WCS coordinates
++    out << "30"			<< std::endl;
++    out << "0"		<< std::endl;	// Z in WCS coordinates
++    out << "11"			<< std::endl;	// End point of line
++    out << PE.X()		<< std::endl;	// X in WCS coordinates
++    out << "21"			<< std::endl;
++    out << PE.Y()		<< std::endl;	// Y in WCS coordinates
++    out << "31"			<< std::endl;
++    out << "0"		<< std::endl;	// Z in WCS coordinates
+ }
+diff --git a/src/Mod/Part/App/Geometry.cpp b/src/Mod/Part/App/Geometry.cpp
+index c206bfb..8403ff2 100644
+--- a/src/Mod/Part/App/Geometry.cpp
++++ b/src/Mod/Part/App/Geometry.cpp
+@@ -203,7 +203,7 @@ unsigned int Geometry::getMemSize (void) const
+ void Geometry::Save(Base::Writer &writer) const
+ {
+     const char c = Construction?'1':'0';
+-    writer.Stream() << writer.ind() << "<Construction value=\"" <<  c << "\"/>" << endl;
++    writer.Stream() << writer.ind() << "<Construction value=\"" <<  c << "\"/>" << std::endl;
+ }
+ 
+ void Geometry::Restore(Base::XMLReader &reader)
+@@ -323,7 +323,7 @@ void GeomPoint::Save(Base::Writer &writer) const
+                 << "X=\"" <<  Point.x <<
+                 "\" Y=\"" <<  Point.y <<
+                 "\" Z=\"" <<  Point.z <<
+-             "\"/>" << endl;
++             "\"/>" << std::endl;
+ }
+ 
+ void GeomPoint::Restore(Base::XMLReader &reader)
+@@ -793,7 +793,7 @@ void GeomBezierCurve::Save(Base::Writer& writer) const
+          << writer.ind()
+              << "<BezierCurve "
+                 << "PolesCount=\"" <<  poles.size() <<
+-             "\">" << endl;
++             "\">" << std::endl;
+ 
+     writer.incInd();
+ 
+@@ -808,11 +808,11 @@ void GeomBezierCurve::Save(Base::Writer& writer) const
+             "\" Y=\"" << (*itp).y <<
+             "\" Z=\"" << (*itp).z <<
+             "\" Weight=\"" << (*itw) <<
+-        "\"/>" << endl;
++        "\"/>" << std::endl;
+     }
+ 
+     writer.decInd();
+-    writer.Stream() << writer.ind() << "</BezierCurve>" << endl ;
++    writer.Stream() << writer.ind() << "</BezierCurve>" << std::endl ;
+ }
+ 
+ void GeomBezierCurve::Restore(Base::XMLReader& reader)
+@@ -1270,7 +1270,7 @@ void GeomBSplineCurve::Save(Base::Writer& writer) const
+                  "\" KnotsCount=\"" <<  knots.size() <<
+                  "\" Degree=\"" <<  degree <<
+                  "\" IsPeriodic=\"" <<  (int) isperiodic <<
+-             "\">" << endl;
++             "\">" << std::endl;
+ 
+     writer.incInd();
+ 
+@@ -1285,7 +1285,7 @@ void GeomBSplineCurve::Save(Base::Writer& writer) const
+             "\" Y=\"" << (*itp).y <<
+             "\" Z=\"" << (*itp).z <<
+             "\" Weight=\"" << (*itw) <<
+-        "\"/>" << endl;
++        "\"/>" << std::endl;
+     }
+ 
+     std::vector<double>::const_iterator itk;
+@@ -1297,11 +1297,11 @@ void GeomBSplineCurve::Save(Base::Writer& writer) const
+             << "<Knot "
+             << "Value=\"" << (*itk)
+             << "\" Mult=\"" << (*itm) <<
+-        "\"/>" << endl;
++        "\"/>" << std::endl;
+     }
+ 
+     writer.decInd();
+-    writer.Stream() << writer.ind() << "</BSplineCurve>" << endl ;
++    writer.Stream() << writer.ind() << "</BSplineCurve>" << std::endl ;
+ }
+ 
+ void GeomBSplineCurve::Restore(Base::XMLReader& reader)
+@@ -1903,7 +1903,7 @@ void GeomCircle::Save(Base::Writer& writer) const
+                 "\" NormalZ=\"" <<  normal.Z() <<
+                 "\" AngleXU=\"" <<  AngleXU <<
+                 "\" Radius=\"" <<  this->myCurve->Radius() <<
+-             "\"/>" << endl;
++             "\"/>" << std::endl;
+ }
+ 
+ void GeomCircle::Restore(Base::XMLReader& reader)
+@@ -2132,7 +2132,7 @@ void GeomArcOfCircle::Save(Base::Writer &writer) const
+                 "\" Radius=\"" <<  circle->Radius() <<
+                 "\" StartAngle=\"" <<  this->myCurve->FirstParameter() <<
+                 "\" EndAngle=\"" <<  this->myCurve->LastParameter() <<
+-             "\"/>" << endl;
++             "\"/>" << std::endl;
+ }
+ 
+ void GeomArcOfCircle::Restore(Base::XMLReader &reader)
+@@ -2383,7 +2383,7 @@ void GeomEllipse::Save(Base::Writer& writer) const
+             << "MajorRadius=\"" <<  this->myCurve->MajorRadius() << "\" "
+             << "MinorRadius=\"" <<  this->myCurve->MinorRadius() << "\" "
+             << "AngleXU=\"" << AngleXU << "\" "
+-            << "/>" << endl;
++            << "/>" << std::endl;
+ }
+ 
+ void GeomEllipse::Restore(Base::XMLReader& reader)
+@@ -2653,7 +2653,7 @@ void GeomArcOfEllipse::Save(Base::Writer &writer) const
+             << "AngleXU=\"" << AngleXU << "\" "
+             << "StartAngle=\"" <<  this->myCurve->FirstParameter() << "\" "
+             << "EndAngle=\"" <<  this->myCurve->LastParameter() << "\" "
+-            << "/>" << endl;
++            << "/>" << std::endl;
+ }
+ 
+ void GeomArcOfEllipse::Restore(Base::XMLReader &reader)
+@@ -2826,7 +2826,7 @@ void GeomHyperbola::Save(Base::Writer& writer) const
+             << "MajorRadius=\"" <<  this->myCurve->MajorRadius() << "\" "
+             << "MinorRadius=\"" <<  this->myCurve->MinorRadius() << "\" "
+             << "AngleXU=\"" << AngleXU << "\" "
+-            << "/>" << endl;
++            << "/>" << std::endl;
+ }
+ 
+ void GeomHyperbola::Restore(Base::XMLReader& reader)
+@@ -3083,7 +3083,7 @@ void GeomArcOfHyperbola::Save(Base::Writer &writer) const
+             << "AngleXU=\"" << AngleXU << "\" "
+             << "StartAngle=\"" <<  this->myCurve->FirstParameter() << "\" "
+             << "EndAngle=\"" <<  this->myCurve->LastParameter() << "\" "
+-            << "/>" << endl;
++            << "/>" << std::endl;
+ }
+ 
+ void GeomArcOfHyperbola::Restore(Base::XMLReader &reader)
+@@ -3236,7 +3236,7 @@ void GeomParabola::Save(Base::Writer& writer) const
+             << "NormalZ=\"" <<  normal.Z() << "\" "
+             << "Focal=\"" <<  this->myCurve->Focal() << "\" "
+             << "AngleXU=\"" << AngleXU << "\" "
+-            << "/>" << endl;
++            << "/>" << std::endl;
+ }
+ 
+ void GeomParabola::Restore(Base::XMLReader& reader)
+@@ -3436,7 +3436,7 @@ void GeomArcOfParabola::Save(Base::Writer &writer) const
+             << "AngleXU=\"" << AngleXU << "\" "
+             << "StartAngle=\"" <<  this->myCurve->FirstParameter() << "\" "
+             << "EndAngle=\"" <<  this->myCurve->LastParameter() << "\" "
+-            << "/>" << endl;
++            << "/>" << std::endl;
+ }
+ 
+ void GeomArcOfParabola::Restore(Base::XMLReader &reader)
+@@ -3581,7 +3581,7 @@ void GeomLine::Save(Base::Writer &writer) const
+                 "\" DirX=\"" <<  Dir.x <<
+                 "\" DirY=\"" <<  Dir.y <<
+                 "\" DirZ=\"" <<  Dir.z <<
+-             "\"/>" << endl;
++             "\"/>" << std::endl;
+ }
+ void GeomLine::Restore(Base::XMLReader &reader)
+ {
+@@ -3722,7 +3722,7 @@ void GeomLineSegment::Save       (Base::Writer &writer) const
+                 "\" EndX=\"" <<  End.x <<
+                 "\" EndY=\"" <<  End.y <<
+                 "\" EndZ=\"" <<  End.z <<
+-             "\"/>" << endl;
++             "\"/>" << std::endl;
+ }
+ 
+ void GeomLineSegment::Restore    (Base::XMLReader &reader)
+diff --git a/src/Mod/Part/App/Geometry2d.cpp b/src/Mod/Part/App/Geometry2d.cpp
+index fb1de90..7a71624 100644
+--- a/src/Mod/Part/App/Geometry2d.cpp
++++ b/src/Mod/Part/App/Geometry2d.cpp
+@@ -183,7 +183,7 @@ void Geom2dPoint::Save(Base::Writer &writer) const
+         << "<Geom2dPoint "
+         << "X=\"" << Point.x << "\" "
+         << "Y=\"" << Point.y << "\" "
+-        << "/>" << endl;
++        << "/>" << std::endl;
+ }
+ 
+ void Geom2dPoint::Restore(Base::XMLReader &reader)
+@@ -875,7 +875,7 @@ void Geom2dCircle::Save(Base::Writer& writer) const
+     SaveAxis(writer, axis);
+     writer.Stream()
+         << "Radius=\"" << c.Radius() << "\" "
+-        << "/>" << endl;
++        << "/>" << std::endl;
+ }
+ 
+ void Geom2dCircle::Restore(Base::XMLReader& reader)
+@@ -990,7 +990,7 @@ void Geom2dArcOfCircle::Save(Base::Writer &writer) const
+     SaveAxis(writer, axis, u, v);
+     writer.Stream()
+         << "Radius=\"" << c.Radius() << "\" "
+-        << "/>" << endl;
++        << "/>" << std::endl;
+ }
+ 
+ void Geom2dArcOfCircle::Restore(Base::XMLReader &reader)
+@@ -1152,7 +1152,7 @@ void Geom2dEllipse::Save(Base::Writer& writer) const
+     writer.Stream()
+         << "MajorRadius=\"" << e.MajorRadius() << "\" "
+         << "MinorRadius=\"" << e.MinorRadius() << "\" "
+-        << "/>" << endl;
++        << "/>" << std::endl;
+ }
+ 
+ void Geom2dEllipse::Restore(Base::XMLReader& reader)
+@@ -1329,7 +1329,7 @@ void Geom2dArcOfEllipse::Save(Base::Writer &writer) const
+     writer.Stream()
+         << "MajorRadius=\"" << e.MajorRadius() << "\" "
+         << "MinorRadius=\"" << e.MinorRadius() << "\" "
+-        << "/>" << endl;
++        << "/>" << std::endl;
+ }
+ 
+ void Geom2dArcOfEllipse::Restore(Base::XMLReader &reader)
+@@ -1458,7 +1458,7 @@ void Geom2dHyperbola::Save(Base::Writer& writer) const
+     writer.Stream()
+         << "MajorRadius=\"" <<  h.MajorRadius() << "\" "
+         << "MinorRadius=\"" <<  h.MinorRadius() << "\" "
+-        << "/>" << endl;
++        << "/>" << std::endl;
+ }
+ 
+ void Geom2dHyperbola::Restore(Base::XMLReader& reader)
+@@ -1591,7 +1591,7 @@ void Geom2dArcOfHyperbola::Save(Base::Writer &writer) const
+     writer.Stream()
+         << "MajorRadius=\"" <<  h.MajorRadius() << "\" "
+         << "MinorRadius=\"" <<  h.MinorRadius() << "\" "
+-        << "/>" << endl;
++        << "/>" << std::endl;
+ }
+ 
+ void Geom2dArcOfHyperbola::Restore(Base::XMLReader &reader)
+@@ -1702,7 +1702,7 @@ void Geom2dParabola::Save(Base::Writer& writer) const
+     SaveAxis(writer, axis);
+     writer.Stream()
+         << "Focal=\"" << focal << "\" "
+-        << "/>" << endl;
++        << "/>" << std::endl;
+ }
+ 
+ void Geom2dParabola::Restore(Base::XMLReader& reader)
+@@ -1815,7 +1815,7 @@ void Geom2dArcOfParabola::Save(Base::Writer &writer) const
+     SaveAxis(writer, axis, u, v);
+     writer.Stream()
+         << "Focal=\"" << focal << "\" "
+-        << "/>" << endl;
++        << "/>" << std::endl;
+ }
+ 
+ void Geom2dArcOfParabola::Restore(Base::XMLReader &reader)
+@@ -1930,7 +1930,7 @@ void Geom2dLine::Save(Base::Writer &writer) const
+         << "PosY=\"" << Pos.y << "\" "
+         << "DirX=\"" << Dir.x << "\" "
+         << "DirY=\"" << Dir.y << "\" "
+-        << "/>" << endl;
++        << "/>" << std::endl;
+ }
+ 
+ void Geom2dLine::Restore(Base::XMLReader &reader)
+@@ -2064,7 +2064,7 @@ void Geom2dLineSegment::Save(Base::Writer &writer) const
+         << "StartY=\"" << Start.y << "\" "
+         << "EndX=\"" << End.x << "\" "
+         << "EndY=\"" << End.y << "\" "
+-        << "/>" << endl;
++        << "/>" << std::endl;
+ }
+ 
+ void Geom2dLineSegment::Restore(Base::XMLReader &reader)
+diff --git a/src/Mod/Part/App/PropertyTopoShape.cpp b/src/Mod/Part/App/PropertyTopoShape.cpp
+index d590a85..892e568 100644
+--- a/src/Mod/Part/App/PropertyTopoShape.cpp
++++ b/src/Mod/Part/App/PropertyTopoShape.cpp
+@@ -281,11 +281,11 @@ static void BRepTools_Write(const TopoDS_Shape& Sh, Standard_OStream& S) {
+ static Standard_Boolean  BRepTools_Write(const TopoDS_Shape& Sh, 
+                                    const Standard_CString File)
+ {
+-  ofstream os;
++  std::ofstream os;
+ #if OCC_VERSION_HEX >= 0x060800
+-  OSD_OpenStream(os, File, ios::out);
++  OSD_OpenStream(os, File, std::ios::out);
+ #else
+-  os.open(File, ios::out);
++  os.open(File, std::ios::out);
+ #endif
+   if (!os.rdbuf()->is_open()) return Standard_False;
+ 
+diff --git a/src/Mod/Raytracing/App/AppRaytracingPy.cpp b/src/Mod/Raytracing/App/AppRaytracingPy.cpp
+index d48c51c..b7677a2 100644
+--- a/src/Mod/Raytracing/App/AppRaytracingPy.cpp
++++ b/src/Mod/Raytracing/App/AppRaytracingPy.cpp
+@@ -105,13 +105,13 @@ private:
+ 
+         PovTools::writeShape(out,PartName,aShape,(float)0.1);
+         // This must not be done in PovTools::writeShape!
+-        out << "// instance to render" << endl
+-            << "object {" << PartName << endl
+-            << "  texture {" << endl
+-            << "      pigment {color rgb <"<<r<<","<<g<<","<<b<<">}" << endl
+-            << "      finish {StdFinish } //definition on top of the project" << endl
+-            << "  }" << endl
+-            << "}" << endl   ;
++        out << "// instance to render" << std::endl
++            << "object {" << PartName << std::endl
++            << "  texture {" << std::endl
++            << "      pigment {color rgb <"<<r<<","<<g<<","<<b<<">}" << std::endl
++            << "      finish {StdFinish } //definition on top of the project" << std::endl
++            << "  }" << std::endl
++            << "}" << std::endl   ;
+         return Py::String(out.str());
+     }
+     Py::Object getPartAsLux(const Py::Tuple& args)
+@@ -128,10 +128,10 @@ private:
+ 
+         // write a material entry
+         // This must not be done in PovTools::writeShape!
+-        out << "MakeNamedMaterial \"FreeCADMaterial_" << PartName << "\"" << endl;
+-        out << "    \"color Kd\" [" << r << " " << g << " " << b << "]" << endl;
+-        out << "    \"float sigma\" [0.000000000000000]" << endl;
+-        out << "    \"string type\" [\"matte\"]" << endl << endl;
++        out << "MakeNamedMaterial \"FreeCADMaterial_" << PartName << "\"" << std::endl;
++        out << "    \"color Kd\" [" << r << " " << g << " " << b << "]" << std::endl;
++        out << "    \"float sigma\" [0.000000000000000]" << std::endl;
++        out << "    \"string type\" [\"matte\"]" << std::endl << std::endl;
+ 
+         LuxTools::writeShape(out,PartName,aShape,(float)0.1);
+         return Py::String(out.str());
+diff --git a/src/Mod/Raytracing/App/LuxFeature.cpp b/src/Mod/Raytracing/App/LuxFeature.cpp
+index 930fe12..e811c9a 100644
+--- a/src/Mod/Raytracing/App/LuxFeature.cpp
++++ b/src/Mod/Raytracing/App/LuxFeature.cpp
+@@ -88,23 +88,23 @@ App::DocumentObjectExecReturn *LuxFeature::execute(void)
+     const App::Color& c = Color.getValue();
+     long t = Transparency.getValue();
+     if (t == 0) {
+-        result << "MakeNamedMaterial \"FreeCADMaterial_" << Name << "\"" << endl
+-               << "    \"color Kd\" [" << c.r << " " << c.g << " " << c.b << "]" << endl
+-               << "    \"float sigma\" [0.000000000000000]" << endl
+-               << "    \"string type\" [\"matte\"]" << endl << endl;
++        result << "MakeNamedMaterial \"FreeCADMaterial_" << Name << "\"" << std::endl
++               << "    \"color Kd\" [" << c.r << " " << c.g << " " << c.b << "]" << std::endl
++               << "    \"float sigma\" [0.000000000000000]" << std::endl
++               << "    \"string type\" [\"matte\"]" << std::endl << std::endl;
+     } else {
+         float trans = t/100.0f;
+-        result << "MakeNamedMaterial \"FreeCADMaterial_Base_" << Name << "\"" << endl
+-               << "    \"color Kd\" [" << c.r << " " << c.g << " " << c.b << "]" << endl
+-               << "    \"float sigma\" [0.000000000000000]" << endl
+-               << "    \"string type\" [\"matte\"]" << endl << endl
+-               << "MakeNamedMaterial \"FreeCADMaterial_Null_" << Name << "\"" << endl
+-               << "    \"string type\" [\"null\"]" << endl << endl
+-               << "MakeNamedMaterial \"FreeCADMaterial_" << Name << "\"" << endl
+-               << "    \"string namedmaterial1\" [\"FreeCADMaterial_Null_" << Name << "\"]" << endl
+-               << "    \"string namedmaterial2\" [\"FreeCADMaterial_Base_" << Name << "\"]" << endl
+-               << "    \"float amount\" [" << trans << "]" << endl
+-               << "    \"string type\" [\"mix\"]" << endl << endl;
++        result << "MakeNamedMaterial \"FreeCADMaterial_Base_" << Name << "\"" << std::endl
++               << "    \"color Kd\" [" << c.r << " " << c.g << " " << c.b << "]" << std::endl
++               << "    \"float sigma\" [0.000000000000000]" << std::endl
++               << "    \"string type\" [\"matte\"]" << std::endl << std::endl
++               << "MakeNamedMaterial \"FreeCADMaterial_Null_" << Name << "\"" << std::endl
++               << "    \"string type\" [\"null\"]" << std::endl << std::endl
++               << "MakeNamedMaterial \"FreeCADMaterial_" << Name << "\"" << std::endl
++               << "    \"string namedmaterial1\" [\"FreeCADMaterial_Null_" << Name << "\"]" << std::endl
++               << "    \"string namedmaterial2\" [\"FreeCADMaterial_Base_" << Name << "\"]" << std::endl
++               << "    \"float amount\" [" << trans << "]" << std::endl
++               << "    \"string type\" [\"mix\"]" << std::endl << std::endl;
+     }
+     
+     LuxTools::writeShape(result,Name.c_str(),shape);
+diff --git a/src/Mod/Raytracing/App/RayFeature.cpp b/src/Mod/Raytracing/App/RayFeature.cpp
+index cdd2cb6..0da9644 100644
+--- a/src/Mod/Raytracing/App/RayFeature.cpp
++++ b/src/Mod/Raytracing/App/RayFeature.cpp
+@@ -81,19 +81,19 @@ App::DocumentObjectExecReturn *RayFeature::execute(void)
+     // This must not be done in PovTools::writeShape!
+     long t = Transparency.getValue();
+     const App::Color& c = Color.getValue();
+-    result << "// instance to render" << endl
+-           << "object {" << Name << endl
+-           << " texture {" << endl;
++    result << "// instance to render" << std::endl
++           << "object {" << Name << std::endl
++           << " texture {" << std::endl;
+     if (t == 0) {
+-        result << "      pigment {color rgb <"<<c.r<<","<<c.g<<","<<c.b<<">}" << endl;
++        result << "      pigment {color rgb <"<<c.r<<","<<c.g<<","<<c.b<<">}" << std::endl;
+     }
+     else {
+         float trans = t/100.0f;
+-        result << "      pigment {color rgb <"<<c.r<<","<<c.g<<","<<c.b<<"> transmit "<<trans<<"}" << endl;
++        result << "      pigment {color rgb <"<<c.r<<","<<c.g<<","<<c.b<<"> transmit "<<trans<<"}" << std::endl;
+     }
+-    result << "      finish {StdFinish } //definition on top of the project" << endl
+-           << "  }" << endl
+-           << "}" << endl   ;
++    result << "      finish {StdFinish } //definition on top of the project" << std::endl
++           << "  }" << std::endl
++           << "}" << std::endl   ;
+ 
+     // Apply the resulting fragment
+     Result.setValue(result.str().c_str());
+-- 
+2.25.0
+

--- a/media-gfx/freecad/freecad-0.18.4.ebuild
+++ b/media-gfx/freecad/freecad-0.18.4.ebuild
@@ -5,7 +5,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_6 )
 
 inherit check-reqs cmake desktop python-single-r1 xdg
 
@@ -153,6 +153,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-0001-Fix-coin-related-variables-to-use-new-naming-from-4.0.0.patch"
 	"${FILESDIR}/${P}-0002-Fix-PySide-related-checks.patch"
 	"${FILESDIR}/${P}-0003-cMake-FindPySide2Tools.cmake-use-generator-option.patch"
+	"${FILESDIR}/${P}-0004-fix-std-namespace-issues.patch"
 )
 
 CHECKREQS_DISK_BUILD="6G"
@@ -297,6 +298,9 @@ src_install() {
 }
 
 pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+
 	if use plot; then
 		einfo "Note: You are enabling the 'plot' USE flag."
 		einfo "This conflicts with the plot workbench which you can load"
@@ -308,4 +312,9 @@ pkg_postinst() {
 		einfo "This conflicts with the ship workbench which you can load"
 		einfo "via the addon manager! You can only install one of those."
 	fi
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }


### PR DESCRIPTION
- use dev-util category, until Gentoo dev-python/pybind11 provides
	cmake config files.
- temporarily remove python 3.7 support, because some dependencies don't
	support it yet.
- fix several issues with missing std:: namespace

Package-Manager: Portage-2.3.86, Repoman-2.3.20
Signed-off-by: Bernd Waibel <waebbl@gmail.com>