### PR TITLE
media-gfx/freecad: Fix opencascade dependency

### DIFF
--- a/media-gfx/freecad/freecad-0.18.4-r1.ebuild
+++ b/media-gfx/freecad/freecad-0.18.4-r1.ebuild
@@ -85,7 +85,7 @@ RDEPEND="
 	sci-libs/flann[mpi?,openmp]
 	>=sci-libs/med-4.0.0-r1[mpi(+)?,python,${PYTHON_SINGLE_USEDEP}]
 	sci-libs/orocos_kdl:=
-	>=sci-libs/opencascade-7.3.0:*[vtk(+)]
+	>=sci-libs/opencascade-7.4.0:*[vtk(+)]
 	sys-libs/zlib
 	virtual/glu
 	virtual/libusb:1


### PR DESCRIPTION
freecad-0.18.4 does not build with opencascade-7.3.0