### PR TITLE
media-gfx/freecad: add <Qt-5.14 compatibility

### DIFF
--- a/media-gfx/freecad/freecad-0.18.4-r1.ebuild
+++ b/media-gfx/freecad/freecad-0.18.4-r1.ebuild
@@ -79,7 +79,7 @@ RDEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	dev-qt/qtxml:5
-	media-libs/coin[draggers(+),manipulators(+),nodekits(+),simage(+),vrml97(+)]
+	>=media-libs/coin-4.0.0[draggers(+),manipulators(+),nodekits(+),simage(+),vrml97(+)]
 	media-libs/freetype
 	media-libs/qhull
 	sci-libs/flann[mpi?,openmp]
@@ -137,7 +137,7 @@ REQUIRED_USE="
 	netgen? ( fem )
 	openscad? ( mesh )
 	path? ( robot )
-	ship? ( image )
+	ship? ( image plot )
 	techdraw? ( spreadsheet drawing )
 "
 
@@ -145,10 +145,10 @@ CMAKE_BUILD_TYPE=Release
 
 DOCS=( README.md ChangeLog.txt )
 
+#	"${FILESDIR}/${P}-0003-cMake-FindPySide2Tools.cmake-use-generator-option.patch"
 PATCHES=(
 	"${FILESDIR}/${P}-0001-Fix-coin-related-variables-to-use-new-naming-from-4.0.0.patch"
 	"${FILESDIR}/${P}-0002-Fix-PySide-related-checks.patch"
-	"${FILESDIR}/${P}-0003-cMake-FindPySide2Tools.cmake-use-generator-option.patch"
 	"${FILESDIR}/${P}-0004-fix-std-namespace-issues.patch"
 )
 
@@ -166,9 +166,19 @@ src_prepare() {
 	# a working one, so we use this.
 	rm -f "${S}/cMake/FindCoin3D.cmake"
 	cmake_src_prepare
+
+	if has_version ">=dev-python/pyside2-tools-5.14.0" || \
+		has_version ">=dev-qt/qtcore-5.14.0"; then
+		eapply "${FILESDIR}/${P}-0003-cMake-FindPySide2Tools.cmake-use-generator-option.patch"
+	fi
 }
 
 src_configure() {
+	local occ_lib="lib"
+	if has_version "=sci-libs/opencascade-7.4.0:7.4.0"; then
+		occ_lib=$(get_libdir)
+	fi
+
 	local mycmakeargs=(
 		-DBUILD_ADDONMGR=$(usex addonmgr)
 		-DBUILD_ARCH=$(usex arch)
@@ -222,7 +232,7 @@ src_configure() {
 		-DFREECAD_USE_PYBIND11=$(usex mesh)
 		# opencascade sets CASROOT in /etc/env.d/51opencascade
 		-DOCC_INCLUDE_DIR="${CASROOT}"/include/opencascade
-		-DOCC_LIBRARY_DIR="${CASROOT}"/$(get_libdir)
+		-DOCC_LIBRARY_DIR="${CASROOT}/${occ_lib}"
 		-DOCCT_CMAKE_FALLBACK=ON # don't use occt-config which isn't included in opencascade for Gentoo
 		-DPYSIDE2RCCBINARY="${EPREFIX}/usr/bin/rcc"
 		-DPYSIDE2UICBINARY="${EPREFIX}/usr/bin/uic"

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -81,7 +81,7 @@ RDEPEND="
 	dev-qt/qtx11extras:5
 	dev-qt/qtxml:5
 	dev-qt/qtxmlpatterns:5
-	media-libs/coin[draggers(+),manipulators(+),nodekits(+),simage(+),vrml97(+)]
+	>=media-libs/coin-4.0.0[draggers(+),manipulators(+),nodekits(+),simage(+),vrml97(+)]
 	media-libs/freetype
 	media-libs/qhull
 	sci-libs/flann[mpi?,openmp]
@@ -139,7 +139,7 @@ REQUIRED_USE="
 	netgen? ( fem )
 	openscad? ( mesh )
 	path? ( robot )
-	ship? ( image )
+	ship? ( image plot )
 	techdraw? ( spreadsheet drawing )
 "
 
@@ -171,6 +171,11 @@ src_prepare() {
 }
 
 src_configure() {
+	local occ_lib="lib"
+	if has_version "=sci-libs/opencascade-7.4.0"; then
+		occ_lib=$(get_libdir)
+	fi
+
 	local mycmakeargs=(
 		-DBUILD_ADDONMGR=$(usex addonmgr)
 		-DBUILD_ARCH=$(usex arch)
@@ -224,7 +229,7 @@ src_configure() {
 		-DFREECAD_USE_PYBIND11=$(usex mesh)
 		# opencascade sets CASROOT in /etc/env.d/51opencascade
 		-DOCC_INCLUDE_DIR="${CASROOT}"/include/opencascade
-		-DOCC_LIBRARY_DIR="${CASROOT}"/$(get_libdir)
+		-DOCC_LIBRARY_DIR="${CASROOT}/${occ_lib}"
 		-DOCCT_CMAKE_FALLBACK=ON # don't use occt-config which isn't included in opencascade for Gentoo
 		-DPYSIDE2RCCBINARY="${EPREFIX}/usr/bin/rcc"
 		-DPYSIDE2UICBINARY="${EPREFIX}/usr/bin/uic"


### PR DESCRIPTION
Only apply generator patch for >=dev-python/pyside2-tools-5.14.0.
Thanks to @CaptainBloodz for reporting the issue.

Also apply a patch to enable freecad to build against opencascade-7.3.0
as well as opencascade-7.4.0, due to library install path changes between
the two versions.
Thanks to @robert7k for bringing this to my attention.

Reported-by: @CaptainBloodz
Reported-by: @robert7k
Closes: https://github.com/waebbl/waebbl-gentoo/issues/194
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Bernd Waibel <waebbl@gmail.com>