### PR TITLE
media-libs/quarter: fix libdir in Quarter.pc file

### DIFF
--- a/media-libs/quarter/quarter-1.1.0.ebuild
+++ b/media-libs/quarter/quarter-1.1.0.ebuild
@@ -48,6 +48,7 @@ src_prepare() {
 
 	sed -e 's|LIB_DIR_SUFFIXES lib|LIB_DIR_SUFFIXES '$(get_libdir)'|' \
 		-i SIMCMakeMacros/FindSpacenav.cmake || die
+	sed -i "s|/lib\$|/$(get_libdir)|" Quarter.pc.cmake.in || die
 
 	cmake_src_prepare
 }


### PR DESCRIPTION
The `Quarter.pc.cmake.in` has a hardcoded libdir path. This fixes it by using a bit of sed and get_libdir. Ran into this while building FreeCAD.