### PR TITLE
media-gfx/freecad: always use get_libdir for opencascade

### DIFF
--- a/media-gfx/freecad/freecad-0.18.4-r1.ebuild
+++ b/media-gfx/freecad/freecad-0.18.4-r1.ebuild
@@ -168,11 +168,6 @@ src_prepare() {
 }
 
 src_configure() {
-	local occ_lib="lib"
-	if has_version "=sci-libs/opencascade-7.4.0:7.4.0"; then
-		occ_lib=$(get_libdir)
-	fi
-
 	local mycmakeargs=(
 		-DBUILD_ADDONMGR=$(usex addonmgr)
 		-DBUILD_ARCH=$(usex arch)
@@ -226,7 +221,7 @@ src_configure() {
 		-DFREECAD_USE_PYBIND11=$(usex mesh)
 		# opencascade sets CASROOT in /etc/env.d/51opencascade
 		-DOCC_INCLUDE_DIR="${CASROOT}"/include/opencascade
-		-DOCC_LIBRARY_DIR="${CASROOT}/${occ_lib}"
+		-DOCC_LIBRARY_DIR="${CASROOT}/$(get_libdir)"
 		-DOCCT_CMAKE_FALLBACK=ON # don't use occt-config which isn't included in opencascade for Gentoo
 		-DPYSIDE2RCCBINARY="${EPREFIX}/usr/bin/rcc"
 		-DPYSIDE2UICBINARY="${EPREFIX}/usr/bin/uic"

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -168,11 +168,6 @@ src_prepare() {
 }
 
 src_configure() {
-	local occ_lib="lib"
-	if has_version "=sci-libs/opencascade-7.4.0"; then
-		occ_lib=$(get_libdir)
-	fi
-
 	local mycmakeargs=(
 		-DBUILD_ADDONMGR=$(usex addonmgr)
 		-DBUILD_ARCH=$(usex arch)
@@ -226,7 +221,7 @@ src_configure() {
 		-DFREECAD_USE_PYBIND11=$(usex mesh)
 		# opencascade sets CASROOT in /etc/env.d/51opencascade
 		-DOCC_INCLUDE_DIR="${CASROOT}"/include/opencascade
-		-DOCC_LIBRARY_DIR="${CASROOT}/${occ_lib}"
+		-DOCC_LIBRARY_DIR="${CASROOT}/$(get_libdir)"
 		-DOCCT_CMAKE_FALLBACK=ON # don't use occt-config which isn't included in opencascade for Gentoo
 		-DPYSIDE2RCCBINARY="${EPREFIX}/usr/bin/rcc"
 		-DPYSIDE2UICBINARY="${EPREFIX}/usr/bin/uic"


### PR DESCRIPTION
the current logic fails as it does not take the revisions into account.
Only one version of opencascade remains in the main tree and this one
uses the correct libdir. This fixes https://github.com/waebbl/waebbl-gentoo/issues/228