### PR TITLE
freecad/vtk: enable python3_7

### DIFF
--- a/media-gfx/freecad/freecad-0.18.4-r1.ebuild
+++ b/media-gfx/freecad/freecad-0.18.4-r1.ebuild
@@ -5,7 +5,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_{6,7} )
 
 inherit check-reqs cmake desktop python-single-r1 xdg
 

--- a/profiles/package.use.mask
+++ b/profiles/package.use.mask
@@ -9,7 +9,6 @@
 
 # Bernd Waibel <waebbl@gmail.com> (05 Feb 2020)
 # Some dependencies of vtk don't support python 3.{7,8} yet
-sci-libs/vtk python_single_target_python3_7 python_targets_python3_7
 sci-libs/vtk python_single_target_python3_8 python_targets_python3_8
 
 # Bernd Waibel <waebbl@gmail.com> (20 Jan 2020)

--- a/sci-libs/vtk/vtk-8.2.0-r2.ebuild
+++ b/sci-libs/vtk/vtk-8.2.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_{6,7} )
 WEBAPP_OPTIONAL=yes
 WEBAPP_MANUAL_SLOT=yes
 


### PR DESCRIPTION
VTK and freecad build and run successfully with python 3.7, all dependencies are available.