### PR TITLE
media-gfx/freecad: fix boost placeholders problem

### DIFF
--- a/media-gfx/freecad/files/freecad-0.18.4-0007-fix-boost-placeholders-problem.patch
+++ b/media-gfx/freecad/files/freecad-0.18.4-0007-fix-boost-placeholders-problem.patch
@@ -1,0 +1,24 @@
+diff --git a/src/Gui/DAGView/DAGView.cpp b/src/Gui/DAGView/DAGView.cpp
+index 501a424a2..229d32cbb 100644
+--- a/src/Gui/DAGView/DAGView.cpp
++++ b/src/Gui/DAGView/DAGView.cpp
+@@ -37,6 +37,7 @@
+ #include "DAGModel.h"
+ #include "DAGView.h"
+ 
++using namespace boost::placeholders;
+ using namespace Gui;
+ using namespace DAG;
+ 
+diff --git a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
+index 8b0e88478..4e0c8eacb 100644
+--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
++++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
+@@ -38,6 +38,7 @@
+ 
+ #include "ViewProviderSketch.h"
+ 
++using namespace boost::placeholders;
+ using namespace SketcherGui;
+ using namespace Gui::TaskView;
+ 

--- a/media-gfx/freecad/freecad-0.18.4-r1.ebuild
+++ b/media-gfx/freecad/freecad-0.18.4-r1.ebuild
@@ -151,6 +151,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-0004-fix-std-namespace-issues.patch"
 	"${FILESDIR}/${P}-0005-Fix-a-Qt-related-crash-with-draft-workbench.patch"
 	"${FILESDIR}/${P}-0006-add-missing-include-statements.patch"
+	"${FILESDIR}/${P}-0007-fix-boost-placeholders-problem.patch"
 )
 
 CHECKREQS_DISK_BUILD="6G"


### PR DESCRIPTION
Closes: https://github.com/waebbl/waebbl-gentoo/issues/250
Package-Manager: Portage-3.0.5, Repoman-3.0.1
Signed-off-by: Huang Rui <vowstar@gmail.com>