### PR TITLE
media-gfx/freecad: update for upstream changes

### DIFF
--- a/media-gfx/freecad/files/freecad-9999-0001-Gentoo-specific-disable-building-assembly-workbench.patch
+++ b/media-gfx/freecad/files/freecad-9999-0001-Gentoo-specific-disable-building-assembly-workbench.patch
@@ -28,7 +28,7 @@ index 7274639ea..05c64d401 100644
 +	if (NOT CMAKE_BUILD_TYPE MATCHES "Gentoo")
 +        option(BUILD_ASSEMBLY "Build the FreeCAD Assembly module" OFF)
 +    endif()
-     option(BUILD_COMPLETE "Build the FreeCAD complete module" ON)
+     option(BUILD_COMPLETE "Build the FreeCAD complete module" OFF)
      option(BUILD_DRAFT "Build the FreeCAD draft module" ON)
      option(BUILD_DRAWING "Build the FreeCAD drawing module" ON)
 diff --git a/src/Mod/CMakeLists.txt b/src/Mod/CMakeLists.txt


### PR DESCRIPTION
The patch fixes an issue where the complete workbench has been
set to default OFF, while the
${P}-0001-Gentoo-specific-disable-building-assembly-workbench.patch
has still set it to ON.

Reported-by: Miroslav Šulc <fordfrog@gentoo.org>
Closes: https://github.com/waebbl/waebbl-gentoo/issues/255
Package-Manager: Portage-3.0.8, Repoman-3.0.1
Signed-off-by: Bernd Waibel <waebbl@gmail.com>