### PR TITLE
sci-mathematics/netgen: fix dependency

### DIFF
--- a/sci-mathematics/netgen/netgen-6.2.1910.ebuild
+++ b/sci-mathematics/netgen/netgen-6.2.1910.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	x11-libs/libX11:=
 	x11-libs/libXext:=
 	x11-libs/libXmu:=
-	ffmpeg? ( virtual/ffmpeg )
+	ffmpeg? ( media-video/ffmpeg )
 	jpeg? ( virtual/jpeg:0= )
 	python? (
 		$(python_gen_cond_dep \


### PR DESCRIPTION
change dependency for obsolete virtual/ffmpeg

Package-Manager: Portage-3.0.8, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl@gmail.com>