### PR TITLE
media-gfx/freecad: small fixes

### DIFF
--- a/media-gfx/freecad/freecad-0.18.5-r2.ebuild
+++ b/media-gfx/freecad/freecad-0.18.5-r2.ebuild
@@ -163,8 +163,11 @@ src_prepare() {
 
 	# Fix OpenCASCADE lookup
 	sed -e 's|/usr/include/opencascade|${CASROOT}/include/opencascade|' \
-		-e 's|/usr/lib\$|${CASROOT}/'$(get_libdir)' NO DEFAULT PATH|' \
+		-e 's|/usr/lib|${CASROOT}/'$(get_libdir)' NO_DEFAULT_PATH|' \
 		-i cMake/FindOpenCasCade.cmake || die
+
+	# Fix desktop file
+	sed -e 's/Exec=FreeCAD/Exec=freecad/' -i src/XDGData/org.freecadweb.FreeCAD.desktop || die
 
 	cmake_src_prepare
 }

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -151,8 +151,11 @@ src_prepare() {
 
 	# Fix OpenCASCADE lookup
 	sed -e 's|/usr/include/opencascade|${CASROOT}/include/opencascade|' \
-		-e 's|/usr/lib\$|${CASROOT}/'$(get_libdir)' NO DEFAULT PATH|' \
+		-e 's|/usr/lib|${CASROOT}/'$(get_libdir)' NO_DEFAULT_PATH|' \
 		-i cMake/FindOpenCasCade.cmake || die
+
+	# Fix desktop file
+	sed -e 's/Exec=FreeCAD/Exec=freecad/' -i src/XDGData/org.freecadweb.FreeCAD.desktop || die
 
 	cmake_src_prepare
 }


### PR DESCRIPTION
- Fix an issue with opencascade, where the oce libraries will
be linked, if both, sci-libs/opencascade and sci-libs/oce
are installed.
- Fix the exec line of the desktop file to use the lower case
symlink.

Thanks to @chl-repo for pointing out the desktop file issue.

Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl@gmail.com>