### PR TITLE
sci-libs/vtk: fix pugixml dependency

### DIFF
--- a/sci-libs/vtk/vtk-8.2.0-r2.ebuild
+++ b/sci-libs/vtk/vtk-8.2.0-r2.ebuild
@@ -47,7 +47,7 @@ RDEPEND="
 	dev-libs/expat
 	dev-libs/jsoncpp:=
 	dev-libs/libxml2:2
-	dev-libs/pugixml
+	>=dev-libs/pugixml-1.11.4
 	>=media-libs/freetype-2.5.4
 	media-libs/glew:0=
 	>=media-libs/libharu-2.3.0-r2


### PR DESCRIPTION
Build fails with current stable pugixml-1.10

Reported-by: @RayOfLight1

Closes: https://github.com/waebbl/waebbl-gentoo/issues/277
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl@gmail.com>