### PR TITLE
media-gfx/freecad: remove pyside2 tools

### DIFF
--- a/media-gfx/freecad/freecad-0.18.5-r2.ebuild
+++ b/media-gfx/freecad/freecad-0.18.5-r2.ebuild
@@ -71,7 +71,7 @@ RDEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	dev-qt/qtxml:5
-	>=media-libs/coin-4.0.0[draggers(+),manipulators(+),nodekits(+),simage(+),vrml97(+)]
+	>=media-libs/coin-4.0.0
 	media-libs/freetype
 	media-libs/qhull
 	sci-libs/flann[openmp]
@@ -104,10 +104,6 @@ DEPEND="${RDEPEND}"
 BDEPEND="
 	dev-lang/swig
 	doc? ( app-arch/p7zip )
-	$(python_gen_cond_dep '
-		!dev-python/pyside-tools:2[${PYTHON_MULTI_USEDEP}]
-		dev-python/pyside2-tools[${PYTHON_MULTI_USEDEP}]
-	')
 "
 
 # To get required dependencies: 'grep REQUIRES_MODS CMakeLists.txt'
@@ -327,7 +323,5 @@ pkg_postinst() {
 }
 
 pkg_postrm() {
-#	xdg_desktop_database_update
-#	xdg_mimeinfo_database_update
 	xdg_pkg_postrm
 }

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -70,7 +70,7 @@ RDEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	dev-qt/qtxml:5
-	>=media-libs/coin-4.0.0[draggers(+),manipulators(+),nodekits(+),simage(+),vrml97(+)]
+	>=media-libs/coin-4.0.0
 	media-libs/freetype
 	media-libs/qhull
 	sci-libs/flann[openmp]
@@ -101,10 +101,6 @@ DEPEND="${RDEPEND}"
 BDEPEND="
 	dev-lang/swig
 	doc? ( app-arch/p7zip )
-	$(python_gen_cond_dep '
-		!dev-python/pyside-tools:2[${PYTHON_MULTI_USEDEP}]
-		dev-python/pyside2-tools[${PYTHON_MULTI_USEDEP}]
-	')
 "
 
 # To get required dependencies:


### PR DESCRIPTION
The package dev-python/pyside2-tools is no longer needed, as the standard `uic` and `rcc` tools from Qt5 are supporting generation of python files, from `.ui` or `.rc` files, respectively.

Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl@gmail.com>
