### PR TITLE
.travis.yml: update versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@
 #
 language: python
 python:
-    - "3.7"
+    - "3.8"
 env:
-    - PORTAGE_VER="2.3.94"
+    - PORTAGE_VER="3.0.12"
 before_install:
     - sudo apt-get -qq update
     - pip install lxml pyyaml


### PR DESCRIPTION
Use python-3.8 and portage-3.0.12

Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl@gmail.com>