### PR TITLE
metadata/layout.conf: update masters

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -4,7 +4,7 @@
 # For details on this file, see the layout.conf section of the
 # portage(5) man page.
 
-masters = gentoo raiagent
+masters = gentoo
 
 # manifest-hashes specify hashes used for new/updated entries
 # https://archives.gentoo.org/gentoo-dev/message/ba2e5d9666ebd7e1bff1143485a37856


### PR DESCRIPTION
Remove raiagent overlay from masters, it's not needed anymore
due to pyside2-tools being in ::gentoo now.

Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl@gmail.com>