### PR TITLE
.travis.yml: remove option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ before_script:
     - ln -s /var/db/repos/gentoo/profiles/default/linux/amd64/17.0 /etc/portage/make.profile
     - cd travis-overlay
 script:
-    - ./../spinner.sh "python ../portage-portage-${PORTAGE_VER}/repoman/bin/repoman full -d -x -i"
+    - ./../spinner.sh "python ../portage-portage-${PORTAGE_VER}/repoman/bin/repoman full -d -x"
 	- pkgcheck scan --exit


### PR DESCRIPTION
Remove the -i (--ignore-arches) option

Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl@gmail.com>