### PR TITLE
openexr-3 packages

### DIFF
--- a/dev-libs/imath/files/imath-9999-0001-fix-link-file-name-for-libPyImath_Python.patch
+++ b/dev-libs/imath/files/imath-9999-0001-fix-link-file-name-for-libPyImath_Python.patch
@@ -1,0 +1,24 @@
+From d8d6a8100232d42cc6ca1941685b0f0e41acfb17 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Thu, 25 Feb 2021 20:30:16 +0100
+Subject: [PATCH] fix link file name for libPyImath_Python
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ src/python/PyImath.pc.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/python/PyImath.pc.in b/src/python/PyImath.pc.in
+index a590fdd..8562b3d 100644
+--- a/src/python/PyImath.pc.in
++++ b/src/python/PyImath.pc.in
+@@ -12,5 +12,5 @@ libsuffix=@LIB_SUFFIX_DASH@
+ Name: PyImath
+ Description: Python bindings for the Imath libraries
+ Version: @IMATH_VERSION@
+-Libs: -L${libdir} -lImath${libsuffix} -lPyImath${libsuffix}
++Libs: -L${libdir} -lImath${libsuffix} -lPyImath@PYIMATH_LIB_PYTHONVER_ROOT@@Python3_VERSION_MAJOR@_@Python3_VERSION_MINOR@${libsuffix}
+ Cflags: -I${includedir} -I${includedir}/Imath
+-- 
+2.30.1
+

--- a/dev-libs/imath/imath-9999.ebuild
+++ b/dev-libs/imath/imath-9999.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+CMAKE_ECLASS=cmake
+PYTHON_COMPAT=( python3_{7..9} )
+
+inherit cmake python-single-r1
+
+DESCRIPTION="Imath basic math package"
+HOMEPAGE="https://www.openexr.com"
+
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/AcademySoftwareFoundation/Imath.git"
+else
+	SRC_URI="https://github.com/AcademySoftwareFoundation/Imath/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+#KEYWORDS="~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x64-macos ~x86-solaris"
+fi
+
+LICENSE="BSD"
+SLOT="3/26"
+IUSE="large-stack python static-libs test"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+RESTRICT="!test? ( test )"
+
+# libImath.so conflicts with ilmbase
+RDEPEND="
+	!media-libs/ilmbase
+	sys-libs/zlib
+	python? (
+		${PYTHON_DEPS}
+		$(python_gen_cond_dep '
+			dev-libs/boost:=[python?,${PYTHON_MULTI_USEDEP}]
+			dev-python/numpy[${PYTHON_MULTI_USEDEP}]
+		')
+	)
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-0001-fix-link-file-name-for-libPyImath_Python.patch
+)
+
+DOCS=( CHANGES.md CODE_OF_CONDUCT.md CONTRIBUTING.md CONTRIBUTORS.md
+	README.md SECURITY.md )
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DIMATH_BUILD_BOTH_STATIC_SHARED=$(usex static-libs)
+		-DIMATH_ENABLE_LARGE_STACK=$(usex large-stack)
+		-DIMATH_INSTALL_PKG_CONFIG=ON
+		-DIMATH_USE_CLANG_TIDY=OFF
+	)
+
+	if use python; then
+		mycmakeargs+=(
+			-DCMAKE_DISABLE_FIND_PACKAGE_Python2=TRUE
+			-DPYTHON=ON
+			-DPython3_EXECUTABLE="${PYTHON}"
+			-DPython3_INCLUDE_DIR=$(python_get_includedir)
+			-DPython3_LIBRARY=$(python_get_library_path)
+		)
+	fi
+
+	cmake_src_configure
+}

--- a/dev-libs/imath/metadata.xml
+++ b/dev-libs/imath/metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>waebbl-gentoo@posteo.net</email>
+		<name>Bernd Waibel</name>
+	</maintainer>
+	<use>
+		<flag name="large-stack">
+			Enables code to take advantage of large stack support
+		</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">AcademySoftwareFoundation/openexr</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/media-libs/openexr/metadata.xml
+++ b/media-libs/openexr/metadata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>waebbl-gentoo@posteo.net</email>
+		<name>Bernd Waibel</name>
+	</maintainer>
+	<use>
+		<flag name="large-stack">
+			Enable code to take advantage of large stack support.
+		</flag>
+		<flag name="utils">
+			Build several utility binaries for verifying and manipulating EXR files.
+		</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">AcademySoftwareFoundation/openexr</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/media-libs/openexr/openexr-9999.ebuild
+++ b/media-libs/openexr/openexr-9999.ebuild
@@ -1,0 +1,72 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+CMAKE_ECLASS=cmake
+
+inherit cmake-multilib
+
+DESCRIPTION="ILM's OpenEXR high dynamic-range image file format libraries"
+HOMEPAGE="https://www.openexr.com/"
+
+if [[ ${PV} = *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/AcademySoftwareFoundation/openexr.git"
+else
+	SRC_URI="https://github.com/AcademySoftwareFoundation/openexr/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-solaris"
+fi
+
+LICENSE="BSD"
+SLOT="3/26" # based on SONAME
+IUSE="cpu_flags_x86_avx doc examples large-stack utils test +threads"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	!media-libs/ilmbase
+	dev-libs/imath:=
+	sys-libs/zlib[${MULTILIB_USEDEP}]
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+#S="${WORKDIR}/${P}/OpenEXR"
+
+DOCS=( CHANGES.md CODEOWNERS CODE_OF_CONDUCT.md CONTRIBUTING.md
+	CONTRIBUTORS.md GOVERNANCE.md PATENTS README.md SECURITY.md )
+
+#src_prepare() {
+	# Fix path for testsuite
+#	sed -i -e "s:/var/tmp/:${T}:" "${S}"/IlmImfTest/tmpDir.h || die "failed to set temp path for tests"
+
+#	if use abi_x86_32 && use test; then
+#		eapply "${FILESDIR}/${PN}-2.5.2-0001-IlmImfTest-main.cpp-disable-tests.patch"
+#	fi
+#
+#	multilib_foreach_abi cmake_src_prepare
+#}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DBUILD_SHARED_LIBS=ON
+		-DBUILD_TESTING=$(usex test)
+		-DINSTALL_OPENEXR_EXAMPLES=$(usex examples)
+		-DOPENEXR_BUILD_UTILS=$(usex utils)
+		-DOPENEXR_ENABLE_LARGE_STACK=$(usex large-stack)
+		-DOPENEXR_ENABLE_THREADING=$(usex threads)
+		-DOPENEXR_INSTALL_PKG_CONFIG=ON
+		-DOPENEXR_USE_CLANG_TIDY=OFF		# don't look for clang-tidy
+	)
+
+	cmake_src_configure
+}
+
+multilib_src_install_all() {
+	if use doc; then
+		DOCS+=( docs/*.pdf )
+	fi
+	einstalldocs
+
+	use examples && docompress -x /usr/share/doc/${PF}/examples
+}


### PR DESCRIPTION
media-libs/openexr: add live package
Features the upcoming release 3 of openexr.
Revdep compatibility with <openexr-3 not tested!

Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

dev-libs/imath: new package (live)
Successor package for the {,Py}Imath parts of
media-libs/ilmbase and dev-python/pyilmbase. The other
other {,py}ilmbase libraries are part of media-libs/openexr.

Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
In preparation for upcoming openexr-3.

Not for use in production yet! Check revdeps.

