### PR TITLE
sci-libs/calculix-ccx: fix compilation with gcc-10

### DIFF
--- a/sci-libs/calculix-ccx/calculix-ccx-2.10.ebuild
+++ b/sci-libs/calculix-ccx/calculix-ccx-2.10.ebuild
@@ -39,6 +39,12 @@ src_configure() {
 	# Keeping things this way in case we change pkgconfig for arpack
 	export LAPACK=$($(tc-getPKG_CONFIG) --libs lapack)
 
+	# allow compilation with gcc-10
+	# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=957064
+	if test-flag-FC -fallow-argument-mismatch; then                                                                                                                                                                                            
+		append-fflags -fallow-argument-mismatch                                                                                                                                                                                                
+	fi
+
 	append-cflags "-I/usr/include/spooles -DSPOOLES"
 	if use threads; then
 		append-cflags "-DUSE_MT"


### PR DESCRIPTION
Fixing https://github.com/waebbl/waebbl-gentoo/issues/307