### PR TITLE
media-gfx/freecad: fix opencascade issues

### DIFF
--- a/media-gfx/freecad/files/freecad-0.19.1-0001-Gentoo-specific-Remove-ccache-usage.patch
+++ b/media-gfx/freecad/files/freecad-0.19.1-0001-Gentoo-specific-Remove-ccache-usage.patch
@@ -1,0 +1,29 @@
+From 74664bf8c9142320be335ab91dca53cb1a1187a2 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Fri, 12 Mar 2021 23:55:09 +0100
+Subject: [PATCH] [Gentoo specific] Remove ccache usage
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ CMakeLists.txt | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5b17736..38e482a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,11 +8,6 @@ if (POLICY CMP0072)
+     cmake_policy(SET CMP0072 OLD)
+ endif(POLICY CMP0072)
+ 
+-find_program(CCACHE_PROGRAM ccache)  #This check should occur before project()
+-if(CCACHE_PROGRAM)
+-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+-endif()
+-
+ project(FreeCAD)
+ 
+ set(PACKAGE_VERSION_NAME "Vulcan")
+-- 
+2.30.1
+

--- a/media-gfx/freecad/files/freecad-0.19_pre20201231-0003-Gentoo-specific-don-t-check-vcs.patch
+++ b/media-gfx/freecad/files/freecad-0.19_pre20201231-0003-Gentoo-specific-don-t-check-vcs.patch
@@ -1,0 +1,26 @@
+From acc8a26b73a87ae024bce30e9f1531610b6e0e5f Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sat, 13 Feb 2021 14:54:28 +0100
+Subject: [PATCH] [Gentoo specific] don't check vcs
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ src/Tools/SubWCRev.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Tools/SubWCRev.py b/src/Tools/SubWCRev.py
+index 9795450..59938bd 100644
+--- a/src/Tools/SubWCRev.py
++++ b/src/Tools/SubWCRev.py
+@@ -455,7 +455,7 @@ def main():
+         if o in ("-b", "--bindir"):
+             bindir = a
+ 
+-    vcs=[GitControl(), DebianGitHub(), BazaarControl(), Subversion(), MercurialControl(), DebianChangelog(), UnknownControl()]
++    vcs=[UnknownControl()]
+     for i in vcs:
+         if i.extractInfo(srcdir, bindir):
+             # Open the template file and the version file
+-- 
+2.30.1
+

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -6,20 +6,21 @@ EAPI=7
 # vtk needs updating to use 3.9
 PYTHON_COMPAT=( python3_{7,8} )
 
-inherit check-reqs cmake desktop optfeature python-single-r1 xdg
+inherit check-reqs cmake desktop eapi8-dosym optfeature python-single-r1 xdg
 
 DESCRIPTION="QT based Computer Aided Design application"
 HOMEPAGE="https://www.freecadweb.org/ https://github.com/FreeCAD/FreeCAD"
 
+MY_PN=FreeCAD
+
 if [[ ${PV} = *9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://github.com/FreeCAD/FreeCAD.git"
+	EGIT_REPO_URI="https://github.com/${MY_PN}/${MY_PN}.git"
 	S="${WORKDIR}/freecad-${PV}"
 else
 	MY_PV=$(ver_cut 1-2)
 	MY_PV=$(ver_rs 1 '_' ${MY_PV})
-	SRC_URI="https://github.com/FreeCAD/FreeCAD/archive/${PV}.tar.gz -> ${P}.tar.gz
-		doc? ( https://github.com/FreeCAD/FreeCAD/releases/download/0.18.1/FreeCAD.${MY_PV}.Quick.Reference.Guide.7z -> ${P}.Quick.Reference.Guide.7z )"
+	SRC_URI="https://github.com/${MY_PN}/${MY_PN}/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64"
 	S="${WORKDIR}/FreeCAD-${PV}"
 fi
@@ -32,13 +33,9 @@ IUSE="debug headless pcl test"
 RESTRICT="!test? ( test )"
 
 FREECAD_EXPERIMENTAL_MODULES="cloud plot ship"
-#FREECAD_DEBUG_MODULES="sandbox template"
-FREECAD_STABLE_MODULES="addonmgr arch drawing fem idf image
-	inspection material mesh openscad part-design path points
-	raytracing robot show spreadsheet surface techdraw tux"
-FREECAD_DISABLED_MODULES="vr"
-FREECAD_ALL_MODULES="${FREECAD_STABLE_MODULES}
-	${FREECAD_EXPERIMENTAL_MODULES} ${FREECAD_DISABLED_MODULES}"
+FREECAD_STABLE_MODULES="addonmgr fem idf image inspection material
+	openscad part-design path points raytracing robot show surface
+	techdraw tux"
 
 for module in ${FREECAD_STABLE_MODULES}; do
 	IUSE="${IUSE} +${module}"
@@ -48,14 +45,12 @@ for module in ${FREECAD_EXPERIMENTAL_MODULES}; do
 done
 unset module
 
-# FIXME: netgen needs updating of python support (currently only 3.6 supported)
-#	netgen? ( >=sci-mathematics/netgen-6.2.1810[python,opencascade,${PYTHON_SINGLE_USEDEP}] )
 RDEPEND="
 	${PYTHON_DEPS}
 	>=dev-cpp/eigen-3.3.1:3
 	dev-libs/OpenNI2[opengl(+)]
 	dev-libs/libspnav[X]
-	dev-libs/xerces-c
+	dev-libs/xerces-c[icu]
 	dev-qt/designer:5
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
@@ -72,6 +67,7 @@ RDEPEND="
 	media-libs/freetype
 	media-libs/qhull
 	sci-libs/flann[openmp]
+	sci-libs/hdf5:=[fortran,zlib]
 	>=sci-libs/med-4.0.0-r1[python,${PYTHON_SINGLE_USEDEP}]
 	sci-libs/opencascade:=[vtk(+)]
 	sci-libs/orocos_kdl:=
@@ -84,7 +80,6 @@ RDEPEND="
 		net-misc/curl
 	)
 	fem? ( <sci-libs/vtk-9[boost,python,qt5,rendering,${PYTHON_SINGLE_USEDEP}] )
-	mesh? ( sci-libs/hdf5:=[fortran,zlib] )
 	openscad? ( media-gfx/openscad )
 	pcl? ( >=sci-libs/pcl-1.8.1:=[opengl,openni2(+),qt5(+),vtk(+)] )
 	$(python_gen_cond_dep '
@@ -92,10 +87,11 @@ RDEPEND="
 		dev-python/matplotlib[${PYTHON_MULTI_USEDEP}]
 		dev-python/numpy[${PYTHON_MULTI_USEDEP}]
 		>=dev-python/pivy-0.6.5[${PYTHON_MULTI_USEDEP}]
+		dev-python/pybind11[${PYTHON_MULTI_USEDEP}]
 		dev-python/pyside2[gui,svg,${PYTHON_MULTI_USEDEP}]
 		dev-python/shiboken2[${PYTHON_MULTI_USEDEP}]
 		addonmgr? ( dev-python/GitPython[${PYTHON_MULTI_USEDEP}] )
-		mesh? ( dev-python/pybind11[${PYTHON_MULTI_USEDEP}] )
+		fem? ( dev-python/ply[${PYTHON_MULTI_USEDEP}] )
 	')
 "
 DEPEND="${RDEPEND}"
@@ -104,35 +100,31 @@ BDEPEND="dev-lang/swig"
 # To get required dependencies:
 # 'grep REQUIRES_MODS cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake'
 # We set the following requirements by default:
-# draft, import, part, qt5, sketcher, start, web.
+# arch, draft, drawing, import, mesh, part, qt5, sketcher, spreadsheet, start, web.
 #
-# Additionally if mesh is set, we auto-enable mesh_part, flat_mesh and smesh
+# Additionally, we auto-enable mesh_part, flat_mesh and smesh
 # Fem actually needs smesh, but as long as we don't have a smesh package, we enable
 # smesh through the mesh USE flag. Note however, the fem<-smesh dependency isn't
 # reflected by the REQUIRES_MODS macro, but at
 # cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake:187.
-#	netgen? ( fem )
+#
+# The increase in auto-enabled workbenches is due to their need in parts of the
+# test suite when compiled with a minimal set of USE flags.
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
-	arch? ( mesh )
-	debug? ( mesh )
-	drawing? ( spreadsheet )
-	fem? ( mesh )
-	inspection? ( mesh points )
-	openscad? ( mesh )
-	path? ( mesh robot )
+	inspection? ( points )
+	path? ( robot )
 	ship? ( image plot )
-	techdraw? ( spreadsheet drawing )
 "
 
-#	"${FILESDIR}"/${PN}-0.19_pre20201231-0002-CMakeLists.txt-add-option-for-ccache.patch
 PATCHES=(
-	"${FILESDIR}"/${PN}-0.19_pre20201231-0001-FindCoin3DDoc.cmake-fix-patch-for-coin-docs.patch
+	"${FILESDIR}"/${PN}-0.19_pre20201231-0003-Gentoo-specific-don-t-check-vcs.patch
+	"${FILESDIR}"/${PN}-0.19.1-0001-Gentoo-specific-Remove-ccache-usage.patch
 )
 
-DOCS=( README.md ChangeLog.txt CODE_OF_CONDUCT.md )
+DOCS=( CODE_OF_CONDUCT.md ChangeLog.txt README.md )
 
-CHECKREQS_DISK_BUILD="7G"
+CHECKREQS_DISK_BUILD="2G"
 
 pkg_setup() {
 	check-reqs_pkg_setup
@@ -146,9 +138,20 @@ src_prepare() {
 	rm "${S}/cMake/FindCoin3D.cmake" || die
 
 	# Fix OpenCASCADE lookup
-	sed -e 's|/usr/include/opencascade|${CASROOT}/include/opencascade|' \
-		-e 's|/usr/lib|${CASROOT}/'$(get_libdir)' NO_DEFAULT_PATH|' \
-		-i cMake/FindOpenCasCade.cmake || die
+	local OCC_P=$(best_version sci-libs/opencascade[vtk])
+	OCC_P=${OCC_P#sci-libs/}
+	local OCC_PV=${OCC_P#opencascade-}
+	OCC_PV=$(ver_cut 1-2 ${OCC_PV})
+	# check for CASROOT needed to ensure occ-7.5 is eselected and profile resourced
+	if [[ ${OCC_PV} = 7.5 && ${CASROOT} = "/usr" ]]; then
+		sed -e 's|/usr/include/opencascade|'${CASROOT}'/include/'${OCC_P}'|' \
+			-e 's|/usr/lib|'${CASROOT}'/'$(get_libdir)'/'${OCC_P}' NO_DEFAULT_PATH|' \
+			-i cMake/FindOpenCasCade.cmake || die
+	else
+		sed -e 's|/usr/include/opencascade|${CASROOT}/include/opencascade|' \
+			-e 's|/usr/lib|${CASROOT}/'$(get_libdir)' NO_DEFAULT_PATH|' \
+			-i cMake/FindOpenCasCade.cmake || die
+	fi
 
 	# Fix desktop file
 	sed -e 's/Exec=FreeCAD/Exec=freecad/' -i src/XDGData/org.freecadweb.FreeCAD.desktop || die
@@ -159,16 +162,16 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DBUILD_ADDONMGR=$(usex addonmgr)
-		-DBUILD_ARCH=$(usex arch)
-		-DBUILD_ASSEMBLY=OFF
+		-DBUILD_ARCH=ON
+		-DBUILD_ASSEMBLY=OFF					# deprecated
 		-DBUILD_CLOUD=$(usex cloud)
 		-DBUILD_COMPLETE=OFF					# deprecated
-		-DBUILD_DRAFT=ON						# basic workspace, enable it by default
-		-DBUILD_DRAWING=$(usex drawing)
+		-DBUILD_DRAFT=ON
+		-DBUILD_DRAWING=ON
 		-DBUILD_ENABLE_CXX_STD:STRING="C++14"	# needed for >=boost-1.75.0
 		-DBUILD_FEM=$(usex fem)
 		-DBUILD_FEM_NETGEN=OFF
-		-DBUILD_FLAT_MESH=$(usex mesh)
+		-DBUILD_FLAT_MESH=ON
 		-DBUILD_FORCE_DIRECTORY=ON				# force building in a dedicated directory
 		-DBUILD_FREETYPE=ON						# automagic dep
 		-DBUILD_GUI=$(usex !headless)
@@ -178,10 +181,10 @@ src_configure() {
 		-DBUILD_INSPECTION=$(usex inspection)
 		-DBUILD_JTREADER=OFF					# code has been removed upstream, but option is still there
 		-DBUILD_MATERIAL=$(usex material)
-		-DBUILD_MESH=$(usex mesh)
-		-DBUILD_MESH_PART=$(usex mesh)
+		-DBUILD_MESH=ON
+		-DBUILD_MESH_PART=ON
 		-DBUILD_OPENSCAD=$(usex openscad)
-		-DBUILD_PART=ON							# basic workspace, enable it by default
+		-DBUILD_PART=ON
 		-DBUILD_PART_DESIGN=$(usex part-design)
 		-DBUILD_PATH=$(usex path)
 		-DBUILD_PLOT=$(usex plot)				# conflicts with possible external workbench
@@ -193,11 +196,12 @@ src_configure() {
 		-DBUILD_SHIP=$(usex ship)				# conflicts with possible external workbench
 		-DBUILD_SHOW=$(usex show)
 		-DBUILD_SKETCHER=ON						# needed by draft workspace
-		-DBUILD_SMESH=$(usex mesh)
-		-DBUILD_SPREADSHEET=$(usex spreadsheet)
-		-DBUILD_START=ON						# basic workspace, enable it by default
+		-DBUILD_SMESH=ON
+		-DBUILD_SPREADSHEET=ON
+		-DBUILD_START=ON
 		-DBUILD_SURFACE=$(usex surface)
 		-DBUILD_TECHDRAW=$(usex techdraw)
+		-DBUILD_TEST=ON							# always build test workbench for run-time testing
 		-DBUILD_TUX=$(usex tux)
 		-DBUILD_VR=OFF
 		-DBUILD_WEB=ON							# needed by start workspace
@@ -210,84 +214,88 @@ src_configure() {
 
 		-DFREECAD_BUILD_DEBIAN=OFF
 
-		-DFREECAD_USE_CCACHE=OFF
 		-DFREECAD_USE_EXTERNAL_KDL=ON
 		-DFREECAD_USE_EXTERNAL_SMESH=OFF		# no package in Gentoo
 		-DFREECAD_USE_EXTERNAL_ZIPIOS=OFF		# doesn't work yet, also no package in Gentoo tree
 		-DFREECAD_USE_FREETYPE=ON
 		-DFREECAD_USE_OCC_VARIANT:STRING="Official Version"
 		-DFREECAD_USE_PCL=$(usex pcl)
-		-DFREECAD_USE_PYBIND11=$(usex mesh)
+		-DFREECAD_USE_PYBIND11=ON
 		-DFREECAD_USE_QT_FILEDIALOG=ON
 		-DFREECAD_USE_QTWEBMODULE:STRING="Qt WebEngine"
 
-		-DPython3_EXECUTABLE=${PYTHON}
+		# install python modules to site-packages' dir. True only for the main package,
+		# sub-packages will still be installed inside /usr/lib64/freecad
+		-DINSTALL_TO_SITEPACKAGES=ON
 
-		-DOCC_INCLUDE_DIR="${CASROOT}"/include/opencascade
-		-DOCC_LIBRARY_DIR="${CASROOT}"/$(get_libdir)
+		-DPython3_EXECUTABLE=${PYTHON}
 		-DOCCT_CMAKE_FALLBACK=ON				# don't use occt-config which isn't included in opencascade for Gentoo
 	)
 
-	if use debug; then
+	if has_version ">=sci-libs/opencascade-7.5"; then
+		# bug https://bugs.gentoo.org/788274
+		local OCC_P=$(best_version sci-libs/opencascade[vtk])
+		OCC_P=${OCC_P#sci-libs/}
 		mycmakeargs+=(
-			# sandbox needs mesh support
-			-DBUILD_SANDBOX=$(usex mesh)
+			-DOCC_INCLUDE_DIR="${CASROOT}"/include/${OCC_P}
+			-DOCC_LIBRARY_DIR="${CASROOT}"/$(get_libdir)/${OCC_P}
+		)
+	else
+		# <occ-7.5 uses different layout
+		mycmakeargs+=(
+			-DOCC_INCLUDE_DIR="${CASROOT}"/include/opencascade
+			-DOCC_LIBRARY_DIR="${CASROOT}"/$(get_libdir)
+		)
+	fi
+
+	if use debug; then
+		# BUILD_SANDBOX currently broken, see
+		# https://forum.freecadweb.org/viewtopic.php?f=4&t=36071&start=30#p504595
+		mycmakeargs+=(
+			-DBUILD_SANDBOX=OFF
 			-DBUILD_TEMPLATE=ON
-			-DBUILD_TEST=ON
 		)
 	else
 		mycmakeargs+=(
 			-DBUILD_SANDBOX=OFF
 			-DBUILD_TEMPLATE=OFF
-			-DBUILD_TEST=OFF
 		)
 	fi
 
 	cmake_src_configure
 }
 
+# We use the FreeCADCmd binary instead of the FreeCAD binary here
+# for two reasons:
+# 1. It works out of the box with USE=headless as well, not needing a guard
+# 2. We don't need virtualx.eclass and it's dependencies
+# The exported environment variables are needed, so freecad does know
+# where to save it's temporary files, and where to look and write it's
+# configuration. Without those, there are sandbox violation, when it
+# tries to create /var/lib/portage/home/.FreeCAD directory.
+src_test() {
+	pushd "${BUILD_DIR}" > /dev/null || die
+	export FREECAD_USER_HOME="${HOME}"
+	export FREECAD_USER_DATA="${T}"
+	export FREECAD_USER_TEMP="${T}"
+	nonfatal ./bin/FreeCADCmd --run-test 0
+	popd > /dev/null || die
+}
+
 src_install() {
 	cmake_src_install
 
 	if ! use headless; then
-		dosym ../$(get_libdir)/${PN}/bin/FreeCAD /usr/bin/freecad
-#		mv "${ED}"/usr/$(get_libdir)/freecad/share/* "${ED}"/usr/share || die "failed to move shared ressources"
+		dosym8 -r /usr/$(get_libdir)/${PN}/bin/FreeCAD /usr/bin/freecad
+		mv "${ED}"/usr/$(get_libdir)/freecad/share/* "${ED}"/usr/share || die "failed to move shared ressources"
 	fi
-	dosym ../$(get_libdir)/${PN}/bin/FreeCADCmd /usr/bin/freecadcmd
+	dosym8 -r /usr/$(get_libdir)/${PN}/bin/FreeCADCmd /usr/bin/freecadcmd
 
-#	make_desktop_entry freecad "FreeCAD" "" "" "MimeType=application/x-extension-fcstd;"
+	python_optimize "${ED}"/usr/share/${PN}/data/Mod/Start/StartPage "${ED}"/usr/$(get_libdir)/${PN}{/Ext,/Mod}/
+	# compile main package in python site-packages as well
+	python_optimize
 
-	# install mimetype for FreeCAD files
-#	insinto /usr/share/mime/packages
-#	newins "${FILESDIR}"/${PN}.sharedmimeinfo "${PN}.xml"
-
-#	insinto /usr/share/pixmaps
-#	newins "${S}"/src/Gui/Icons/${PN}.xpm "${PN}.xpm"
-
-	# install icons to correct place rather than /usr/share/freecad
-#	local size
-#	for size in 16 32 48 64; do
-#		newicon -s ${size} "${S}"/src/Gui/Icons/${PN}-icon-${size}.png ${PN}.png
-#	done
-#	doicon -s scalable "${S}"/src/Gui/Icons/${PN}.svg
-#	newicon -s 64 -c mimetypes "${S}"/src/Gui/Icons/${PN}-doc.png application-x-extension-fcstd.png
-
-#	rm "${ED}"/usr/share/${PN}/data/${PN}-{doc,icon-{16,32,48,64}}.png || die
-#	rm "${ED}"/usr/share/${PN}/data/${PN}.svg || die
-#	rm "${ED}"/usr/share/${PN}/data/${PN}.xpm || die
-
-	# FIXME: do we want this?
-	mv "${ED}"/usr/$(get_libdir)/freecad/share/* "${ED}"/usr/share || die "failed to move shared ressources"
-
-	if [[ ${PV} == *9999 ]]; then
-		einfo "Docs are not downloaded for ${PV}"
-	else
-		if use doc; then
-			cp -r "${WORKDIR}/FreeCAD 0_18 Quick Reference Guide" "${ED}/usr/share/doc/${PF}" || die
-		fi
-	fi
-
-	python_optimize "${ED}"/usr/share/${PN}/data/Mod/ "${ED}"/usr/$(get_libdir)/${PN}{/Ext,/Mod}/
+	doenvd "${FILESDIR}/99${PN}"
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Add some guards to select the correct options,
based on the version of sci-libs/opencascade that is
installed and eselected.

Closes: https://github.com/waebbl/waebbl-gentoo/issues/313
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>