### PR TITLE
media-gfx/freecad: add env file

### DIFF
--- a/media-gfx/freecad/files/99freecad
+++ b/media-gfx/freecad/files/99freecad
@@ -1,0 +1,1 @@
+PYTHONPATH=/usr/lib64/freecad/Ext:/usr/lib64/freecad/Mod:/usr/lib64/freecad/lib64


### PR DESCRIPTION
The env file has been forgotten in the latest update
to the live ebuild.

Thanks Jan for reporting this quickly!

Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>