### PR TITLE
github-actions: fix error in pkgcheck.yml

### DIFF
--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Run pkgcheck
       uses: pkgcore/pkgcheck-action@v1
       with:
-        args: --keywords=-RedundantVersion,-MissingAccountIdentifier,-OldPackageUpdate,-VisibleVcsPackage
+        args: --keywords=-RedundantVersion,-MissingAccountIdentifier,-OldPackageUpdate,-VisibleVcsPkg


### PR DESCRIPTION
One the keywords passed, was wrong VisibleVcsPackage -> VisibleVcsPkg

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>