### PR TITLE
sci-libs/calculix-ccx: drop USE=arpack

### DIFF
--- a/sci-libs/calculix-ccx/calculix-ccx-2.17-r1.ebuild
+++ b/sci-libs/calculix-ccx/calculix-ccx-2.17-r1.ebuild
@@ -19,14 +19,14 @@ S=${WORKDIR}/CalculiX/${MY_P}/src
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="arpack doc examples openmp threads"
+IUSE="doc examples openmp threads"
 RESTRICT="test" # FIXME
 
 RDEPEND="
+	>=sci-libs/arpack-3.1.3
 	>=sci-libs/spooles-2.2[threads=]
 	virtual/blas
 	virtual/lapack
-	arpack? ( >=sci-libs/arpack-3.1.3 )
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
@@ -61,10 +61,9 @@ src_configure() {
 		append-cflags "-fopenmp"
 	fi
 
-	if use arpack; then
-		export ARPACKLIB=$($(tc-getPKG_CONFIG) --libs arpack)
-		append-cflags "-DARPACK"
-	fi
+	export ARPACKLIB=$($(tc-getPKG_CONFIG) --libs arpack)
+	append-cflags "-DARPACK"
+
 	export CC="$(tc-getCC)"
 	export FC="$(tc-getFC)"
 }

--- a/sci-libs/calculix-ccx/metadata.xml
+++ b/sci-libs/calculix-ccx/metadata.xml
@@ -5,7 +5,4 @@
 		<email>waebbl-gentoo@posteo.net</email>
 		<name>Bernd Waibel</name>
 	</maintainer>
-	<use>
-		<flag name="arpack"> Add sparse eigen value support via sci-libs/arpack </flag>
-	</use>
 </pkgmetadata>


### PR DESCRIPTION
The arpack package is no longer optional.

Closes: https://github.com/waebbl/waebbl-gentoo/issues/335
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>