### PR TITLE
media-gfx/freecad: install freecad-thumbnailer

### DIFF
--- a/media-gfx/freecad/files/freecad-9999-Add-memory-header-for-std-shared_ptr.patch
+++ b/media-gfx/freecad/files/freecad-9999-Add-memory-header-for-std-shared_ptr.patch
@@ -1,0 +1,32 @@
+From 1e0a7f20594ad49cba15a12f8e9c9aafa75d1e8e Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sat, 16 Oct 2021 17:02:19 +0200
+Subject: [PATCH] Add memory header for std::shared_ptr
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ src/App/Metadata.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/App/Metadata.h b/src/App/Metadata.h
+index de8be3ea8e..2c5fd8f417 100644
+--- a/src/App/Metadata.h
++++ b/src/App/Metadata.h
+@@ -30,6 +30,7 @@
+ #include <string>
+ #include <vector>
+ #include <map>
++#include <memory>
+ 
+ #include <xercesc/dom/DOM.hpp>
+ #include <xercesc/parsers/XercesDOMParser.hpp>
+@@ -296,4 +297,4 @@ namespace App {
+ 
+ }
+ 
+-#endif
+\ No newline at end of file
++#endif
+-- 
+2.33.1
+


### PR DESCRIPTION
- bump to EAPI 8
- need C++17 for boost-1.77.0 to build

Suggested-by: Michael Perlov <perlovka@gmail.com>
Closes: https://github.com/waebbl/waebbl-gentoo/issues/341
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>