### PR TITLE
media-gfx/netgen: keep the libtogl.a libary

### DIFF
--- a/media-gfx/netgen/netgen-6.2.2204.ebuild
+++ b/media-gfx/netgen/netgen-6.2.2204.ebuild
@@ -126,10 +126,6 @@ src_install() {
 	doenvd 99netgen
 
 	if use gui; then
-		# Only used internally, we have togl package
-		# see https://github.com/NGSolve/netgen/issues/126
-		rm "${ED}"/usr/$(get_libdir)/libtogl.a || die
-
 		mv "${ED}"/usr/bin/{*.tcl,*.ocf} "${ED}${NETGENDIR}" || die
 
 		doicon "${FILESDIR}"/${PN}.png


### PR DESCRIPTION
The libtogl.a library is referenced in netgen-targets.cmake.

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>