### PR TITLE
dev-cpp/zipios: add live ebuild (9999)

### DIFF
--- a/dev-cpp/zipios/files/zipios-9999-fix-doc-installation-dir.patch
+++ b/dev-cpp/zipios/files/zipios-9999-fix-doc-installation-dir.patch
@@ -1,0 +1,20 @@
+From 0765b9dc367d50462a9e2f1c958a36cbcfb4bd69 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Fri, 9 Dec 2022 15:38:53 +0100
+Subject: [PATCH] fix doc installation dir
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/doc/CMakeLists.txt
++++ b/doc/CMakeLists.txt
+@@ -70,7 +70,7 @@ if(BUILD_DOCUMENTATION)
+                     ${CMAKE_CURRENT_BINARY_DIR}/${DOCUMENTATION_OUTPUT}/
+ 
+                 DESTINATION
+-                    ${DATA_INSTALL_DIR}/doc/${LOWER_TARGET_NAME}/html/
++                    ${DOC_INSTALL_DIR}/html/
+             )
+             # The following installs the man3 files, we only install the man
+             # pages of public classes. For more details the user will have to
+-- 
+2.38.1
+

--- a/dev-cpp/zipios/files/zipios-9999-use-catch2-name-instead-of-snapcatch2.patch
+++ b/dev-cpp/zipios/files/zipios-9999-use-catch2-name-instead-of-snapcatch2.patch
@@ -1,0 +1,56 @@
+From 0e6ae1632b62b4377149335b09302ebbba15e203 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Fri, 9 Dec 2022 14:20:49 +0100
+Subject: [PATCH] use catch2 name instead of snapcatch2
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -24,9 +24,9 @@ if(BUILD_ZIPIOS_TESTS)
+ 
+     message("Tests are turned ON.")
+ 
+-    find_package(SnapCatch2)
++    find_package(Catch2)
+ 
+-    if(SNAPCATCH2_FOUND)
++    if(CATCH2_FOUND)
+ 
+         add_executable(${PROJECT_NAME}
+             catch_main.cpp
+@@ -49,12 +49,12 @@ if(BUILD_ZIPIOS_TESTS)
+ 
+         target_include_directories(${PROJECT_NAME}
+             PUBLIC
+-                ${SNAPCATCH2_INCLUDE_DIRS}
++                ${CATCH2_INCLUDE_DIRS}
+         )
+ 
+         target_link_libraries(${PROJECT_NAME}
+             zipios
+-            ${SNAPCATCH2_LIBRARIES}
++            ${CATCH2_LIBRARIES}
+         )
+ 
+         add_custom_target(run_zipios_tests
+@@ -66,7 +66,7 @@ if(BUILD_ZIPIOS_TESTS)
+ 
+         add_test(zipios_tests ${PROJECT_NAME})
+ 
+-    else(SNAPCATCH2_FOUND)
++    else(CATCH2_FOUND)
+ 
+         message("No test will be created because you do not seem to have catch.hpp installed...")
+ 
+@@ -75,7 +75,7 @@ if(BUILD_ZIPIOS_TESTS)
+             COMMAND echo "No tests were built because it looks like you are missing Catch2."
+         )
+ 
+-    endif(SNAPCATCH2_FOUND)
++    endif(CATCH2_FOUND)
+ 
+ else(BUILD_ZIPIOS_TESTS)
+ 
+-- 
+2.38.1
+

--- a/dev-cpp/zipios/zipios-9999.ebuild
+++ b/dev-cpp/zipios/zipios-9999.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# FIXME: tests currently don't work. Repo isn't ready for Catch2 v3 and
+# using catch:1 leads ot catch being not being due to missing cmake files
+# and inferior FindCatch from upstream.
+
+EAPI=7
+
+inherit cmake
+
+DESCRIPTION="C++ library for reading and writing zip files"
+HOMEPAGE="https://snapwebsites.org/project/zipios"
+
+if [[ ${PV} = *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/Zipios/Zipios.git"
+else
+	SRC_URI="https://github.com/Zipios/Zipios/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64"
+	S="${WORKDIR}/Zipios-${PV}"
+fi
+
+LICENSE="LGPL-2.1+"
+SLOT="0"
+IUSE="doc"
+
+RESTRICT="test"
+
+RDEPEND="sys-libs/zlib"
+DEPEND="${RDEPEND}"
+BDEPEND="doc? ( app-doc/doxygen[dot] )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.2.6-0005-install-missing-header-files.patch
+	"${FILESDIR}"/${PN}-9999-fix-doc-installation-dir.patch
+)
+
+DOCS=( AUTHORS NEWS README.md )
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_SHARED_LIBS=ON
+		-DBUILD_DOCUMENTATION=$(usex doc)
+		-DBUILD_ZIPIOS_TESTS=OFF
+		-DDOC_INSTALL_DIR=share/doc/${PF}
+		-DRUN_TESTS=OFF
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
- drop tests for this version for now

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>